### PR TITLE
add calendar module

### DIFF
--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 .. moduleauthor:: Andres Gonzalez <atowersc@gmail.com> In inspiration with Tianning Li <ltianningli@gmail.com>
 """
+
 CALENDAR_URL = 'https://finviz.com/calendar.ashx'
 
 class Calendar:
@@ -45,6 +46,7 @@ class Calendar:
             df(pandas.DataFrame): calendar information table
 
         """
+
         df = pd.DataFrame([], columns=['Date', 'Next', 'Release', 'Impact', 'For', 'Val', 'Actual', 'Expected', 'Prior'])
         tables = tables.findAll('tr')[3:]
 
@@ -57,7 +59,7 @@ class Calendar:
                     nexxt = ">>>>"
                 else:
                     nexxt = "    "
-            except:
+            except Exception:
                 pass
             if cols[2].text == "Release":
                 release = "----------"
@@ -85,7 +87,6 @@ class Calendar:
                     val = " < "
             except:
                 val = "---"
-                pass
             if cols[5].text == "Actual":
                 actual = "----------"
             else:

--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -1,0 +1,112 @@
+from finvizfinance.util import webScrap
+import pandas as pd
+"""
+.. module:: Calendar
+   :synopsis: Calendar table.
+
+.. moduleauthor:: Andres Gonzalez <atowersc@gmail.com> In inspiration with Tianning Li <ltianningli@gmail.com>
+"""
+CALENDAR_URL = 'https://finviz.com/calendar.ashx'
+
+class Calendar:
+    """Calendar
+    Getting information from the complete week Calendar page.
+
+    """
+    def __init__(self):
+        """initiate module
+
+        """
+        self.all_calendar = {}
+        self.soup = webScrap(CALENDAR_URL)
+        self.calendar = {}
+
+    def getCalendar(self):
+        """Get calendar information table.
+
+        Retrieves table information from finviz finance calendar.
+
+        Returns:
+            calendar(dict): calendar table
+
+        """
+        tables = self.soup.findAll('table')
+        calendar = tables[3]
+        calendar_df = self._getNewsHelper(calendar)
+
+
+        self.calendar = {'calendar': calendar_df}
+        return self.calendar
+
+    def _getNewsHelper(self, tables):
+        """Get insider information table helper function.
+
+        Returns:
+            df(pandas.DataFrame): calendar information table
+
+        """
+        df = pd.DataFrame([], columns=['Date', 'Next', 'Release', 'Impact', 'For', 'Val', 'Actual', 'Expected', 'Prior'])
+        tables = tables.findAll('tr')[3:]
+
+        for row in tables:
+            cols = row.find_all('td')
+            date = cols[0].text
+            try:
+                attr = row.get("class")
+                if attr[0] == "calendar-now":
+                    nexxt = ">>>>"
+                else:
+                    nexxt = "    "
+            except:
+                pass
+            if cols[2].text == "Release":
+                release = "----------"
+            else:
+                release = cols[2].text
+            imp = row.findAll('img')[1].get("src")
+            if imp.endswith('_1.gif'):
+                impact = "x"
+            else:
+                if imp.endswith('_2.gif'):
+                    impact = "xx"
+                else:
+                    if imp.endswith('_3.gif'):
+                        impact = "xxx"
+                    else:
+                        impact = "----------"
+            if cols[4].text == "For":
+                forr = "----------"
+            else:
+                forr = cols[4].text
+            try:
+                if cols[5].find("span").get("style") == "color:#008800;":
+                    val = " > "
+                else:
+                    val = " < "
+            except:
+                val = "---"
+                pass
+            if cols[5].text == "Actual":
+                actual = "----------"
+            else:
+                actual = cols[5].text
+            if cols[6].text == "Expected":
+                expected = "----------"
+            else:
+                expected = cols[6].text
+            if cols[7].text == "Prior":
+                prior = "----------"
+            else:
+                prior = cols[7].text
+            df = df.append({
+            'Date':date,
+            'Next':nexxt,
+            'Release':release,
+            'Impact':impact,
+            'For':forr,
+            'Val':val,
+            'Actual':actual,
+            'Expected':expected,
+            'Prior':prior},
+            ignore_index=True)
+        return df

--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -1,10 +1,12 @@
 from finvizfinance.util import webScrap
 import pandas as pd
+
 """
 .. module:: Calendar
    :synopsis: Calendar table.
 
-.. moduleauthor:: Andres Gonzalez <atowersc@gmail.com> In inspiration with Tianning Li <ltianningli@gmail.com>
+.. moduleauthor:: Andres Gonzalez <atowersc@gmail.com> 
+In inspiration with Tianning Li <ltianningli@gmail.com> 
 """
 
 CALENDAR_URL = 'https://finviz.com/calendar.ashx'
@@ -53,14 +55,13 @@ class Calendar:
         for row in tables:
             cols = row.find_all('td')
             date = cols[0].text
-            try:
-                attr = row.get("class")
-                if attr[0] == "calendar-now":
-                    nexxt = ">>>>"
-                else:
-                    nexxt = "    "
-            except Exception:
-                pass
+            
+            attr = row.get("class")
+            if str(attr) == "['calendar-now']":
+                nexxt = ">>>>"
+            else:
+                nexxt = "    "
+
             if cols[2].text == "Release":
                 release = "----------"
             else:

--- a/runtest.py
+++ b/runtest.py
@@ -17,6 +17,14 @@ def test_finvizfinance_news():
     assert(blogs is not None)
 
 
+def test_finvizfinance_calendar():
+    from finvizfinance.calendar import Calendar
+    fcalendar = Calendar()
+    all_Calendar = fcalendar.getCalendar()
+    calendar = all_Calendar['calendar']
+    assert(calendar is not None)
+
+
 def test_finvizfinance_insider():
     from finvizfinance.insider import Insider
     finsider = Insider(option='top owner trade')
@@ -69,6 +77,8 @@ if __name__ == "__main__":
     print('Quote module test pass.')
     test_finvizfinance_news()
     print('News module test pass.')
+    test_finvizfinance_calendar()
+    print('Calendar module test pass.')
     test_finvizfinance_insider()
     print('Insider module test pass.')
     test_screener_overview()

--- a/runtest.py
+++ b/runtest.py
@@ -22,8 +22,7 @@ def test_finvizfinance_calendar():
     fcalendar = Calendar()
     all_Calendar = fcalendar.getCalendar()
     calendar = all_Calendar['calendar']
-    print(calendar)
-    #assert(calendar is not None)
+    assert(calendar is not None)
 
 
 def test_finvizfinance_insider():

--- a/runtest.py
+++ b/runtest.py
@@ -22,7 +22,8 @@ def test_finvizfinance_calendar():
     fcalendar = Calendar()
     all_Calendar = fcalendar.getCalendar()
     calendar = all_Calendar['calendar']
-    assert(calendar is not None)
+    print(calendar)
+    #assert(calendar is not None)
 
 
 def test_finvizfinance_insider():


### PR DESCRIPTION
a module that obtains the information from the calendar page with the complete week.
[](https://finviz.com/calendar.ashx)

- Get the information of the next economic events of the whole week.
- shows the impact of the news result in 1 star, 2 or 3
- shows whether the results were better or worse than expected.  ( ">" better than expected), ( "<" worse than expected)
- indicator showing the next event on the economic calendar
![Screenshot 2021-02-25 at 20](https://user-images.githubusercontent.com/78119341/109240545-a535ae80-77a5-11eb-8969-71b9e1e3b99f.png)
