### PR TITLE
Additional insider options

### DIFF
--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -22,10 +22,22 @@ class Insider:
         """
         if option == 'latest':
             self.soup = webScrap(INSIDER_URL)
+        elif option == 'latest buys':
+            self.soup = webScrap(INSIDER_URL+'?tc=1')
+        elif option == 'latest sales':
+            self.soup = webScrap(INSIDER_URL+'?tc=2')
         elif option == 'top week':
             self.soup = webScrap(INSIDER_URL+'?or=-10&tv=100000&tc=7&o=-transactionValue')
+        elif option == 'top week buys':
+            self.soup = webScrap(INSIDER_URL+'?or=-10&tv=100000&tc=1&o=-transactionValue')
+        elif option == 'top week sales':
+            self.soup = webScrap(INSIDER_URL+'?or=-10&tv=100000&tc=2&o=-transactionValue')
         elif option == 'top owner trade':
             self.soup = webScrap(INSIDER_URL+'?or=10&tv=1000000&tc=7&o=-transactionValue')
+        elif option == 'top owner buys':
+            self.soup = webScrap(INSIDER_URL+'?or=10&tv=1000000&tc=1&o=-transactionValue')
+        elif option == 'top owner sales':
+            self.soup = webScrap(INSIDER_URL+'?or=10&tv=1000000&tc=2&o=-transactionValue')
         elif option.isdigit():
             self.soup = webScrap(INSIDER_URL+'?oc='+option+'&tc=7')
         self.df = None

--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -15,7 +15,7 @@ class Insider:
     Getting information from the finviz insider page.
 
     Args:
-        option (str): choose a option (latest, top week, top owner trade, insider_id)
+        option (str): choose a option (latest, latest buys, latest sales, top week, top week buys, top week sales, top owner trade, top owner buys, top owner sales, insider_id)
     """
     def __init__(self, option='latest'):
         """initiate module


### PR DESCRIPTION
Added more options and corresponding URLs to allow for more convenient screening for insider buys and sales. 
Left the existing options as is to not break backwards compatibility. 
Updated corresponding documentation lines to add new options. 

I'm a bit of a python newbie so best i could do to test this was to drop the file into my local library. Appears to be generating the correct data.  The repo tests only appear to test one method so i felt adding more to that was not necessary. 