### PR TITLE
Remove the use of deprecated pandas DataFrame.append() method

### DIFF
--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -26,15 +26,6 @@ class Calendar:
         """
         soup = web_scrap("https://finviz.com/calendar.ashx")
         tables = soup.findAll("table", class_="calendar")
-        columns = [
-            "Datetime",
-            "Release",
-            "Impact",
-            "For",
-            "Actual",
-            "Expected",
-            "Prior",
-        ]
 
         frame = []
         for table in tables:

--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -35,8 +35,8 @@ class Calendar:
             "Expected",
             "Prior",
         ]
-        df = pd.DataFrame([], columns=columns)
 
+        frame = []
         for table in tables:
             rows = table.findAll("tr")
             # check row
@@ -56,5 +56,5 @@ class Calendar:
                         "Expected": cols[6].text,
                         "Prior": cols[7].text,
                     }
-                    df = df.append(info_dict, ignore_index=True)
-        return df
+                    frame.append(info_dict)
+        return pd.DataFrame(frame)

--- a/finvizfinance/group/custom.py
+++ b/finvizfinance/group/custom.py
@@ -83,7 +83,7 @@ class Custom(Overview):
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
         table_header = [i.text for i in rows[0].findAll("td")][1:]
-        df = pd.DataFrame([], columns=table_header)
+        frame = []
         rows = rows[1:]
         num_col_index = list(range(2, len(table_header)))
         for row in rows:
@@ -96,5 +96,5 @@ class Custom(Overview):
                 else:
                     info_dict[table_header[i]] = number_covert(col.text)
 
-            df = df.append(info_dict, ignore_index=True)
-        return df
+            frame.append(info_dict)
+        return pd.DataFrame(frame)

--- a/finvizfinance/group/overview.py
+++ b/finvizfinance/group/overview.py
@@ -95,7 +95,7 @@ class Overview:
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
         table_header = [i.text for i in rows[0].findAll("td")][1:]
-        df = pd.DataFrame([], columns=table_header)
+        frame = []
         rows = rows[1:]
         num_col_index = list(range(2, len(table_header)))
         for row in rows:
@@ -108,5 +108,5 @@ class Overview:
                 else:
                     info_dict[table_header[i]] = number_covert(col.text)
 
-            df = df.append(info_dict, ignore_index=True)
-        return df
+            frame.append(info_dict)
+        return pd.DataFrame(frame)

--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -67,7 +67,7 @@ class Insider:
         table_header = [i.text.strip() for i in rows[0].findAll("td")] + [
             "SEC Form 4 Link"
         ]
-        df = pd.DataFrame([], columns=table_header)
+        frame = []
         rows = rows[1:]
         num_col = ["Cost", "#Shares", "Value ($)", "#Shares Total"]
         num_col_index = [table_header.index(i) for i in table_header if i in num_col]
@@ -82,6 +82,7 @@ class Insider:
                 else:
                     info_dict[table_header[i]] = number_covert(col.text)
                 info_dict["SEC Form 4 Link"] = cols[-1].find("a").attrs["href"]
-            df = df.append(info_dict, ignore_index=True)
+            frame.append(info_dict)
+        df = pd.DataFrame(frame)
         self.df = df
         return df

--- a/finvizfinance/news.py
+++ b/finvizfinance/news.py
@@ -51,7 +51,7 @@ class News:
             df(pandas.DataFrame): news information table
 
         """
-        df = pd.DataFrame([], columns=["Date", "Title", "Source", "Link"])
+        table = []
         rows = rows.findAll("tr")
         for row in rows:
             cols = row.findAll("td")
@@ -61,8 +61,6 @@ class News:
             source = link.split("/")[2]
             if source == "feedproxy.google.com":
                 source = link.split("/")[4]
-            df = df.append(
-                {"Date": date, "Title": title, "Source": source, "Link": link},
-                ignore_index=True,
-            )
-        return df
+            info_dict = {"Date": date, "Title": title, "Source": source, "Link": link}
+            table.append(info_dict)
+        return pd.DataFrame(table)

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -220,7 +220,7 @@ class finvizfinance:
         fullview_ratings_outer = self.soup.find(
             "table", class_="fullview-ratings-outer"
         )
-        df = pd.DataFrame([], columns=["Date", "Status", "Outer", "Rating", "Price"])
+        frame = []
         rows = fullview_ratings_outer.findAll("td", class_="fullview-ratings-inner")
         for row in rows:
             each_row = row.find("tr")
@@ -231,16 +231,15 @@ class finvizfinance:
             outer = cols[2].text
             rating = cols[3].text
             price = cols[4].text
-            df = df.append(
-                {
-                    "Date": date,
-                    "Status": status,
-                    "Outer": outer,
-                    "Rating": rating,
-                    "Price": price,
-                },
-                ignore_index=True,
-            )
+            info_dict = {
+                "Date": date,
+                "Status": status,
+                "Outer": outer,
+                "Rating": rating,
+                "Price": price,
+            }
+            frame.append(info_dict)
+        df = pd.DataFrame(frame)
         self.info["ratings_outer"] = df
         return df
 
@@ -253,8 +252,8 @@ class finvizfinance:
         fullview_news_outer = self.soup.find("table", class_="fullview-news-outer")
         rows = fullview_news_outer.findAll("tr")
 
+        frame = []
         last_date = ""
-        df = pd.DataFrame([], columns=["Date", "Title", "Link"])
         for row in rows:
             cols = row.findAll("td")
             date = cols[0].text
@@ -267,9 +266,9 @@ class finvizfinance:
             else:
                 news_time = last_date + " " + news_time[0]
             news_time = datetime.strptime(news_time, "%b-%d-%y %I:%M%p")
-            df = df.append(
-                {"Date": news_time, "Title": title, "Link": link}, ignore_index=True
-            )
+            info_dict = {"Date": news_time, "Title": title, "Link": link}
+            frame.append(info_dict)
+        df = pd.DataFrame(frame)
         self.info["news"] = df
         return df
 
@@ -283,7 +282,7 @@ class finvizfinance:
         rows = inside_trader.findAll("tr")
         table_header = [i.text for i in rows[0].findAll("td")]
         table_header += ["SEC Form 4 Link", "Insider_id"]
-        df = pd.DataFrame([], columns=table_header)
+        frame = []
         rows = rows[1:]
         num_col = ["Cost", "#Shares", "Value ($)", "#Shares Total"]
         num_col_index = [table_header.index(i) for i in table_header if i in num_col]
@@ -297,7 +296,8 @@ class finvizfinance:
                     info_dict[table_header[i]] = number_covert(col.text)
             info_dict["SEC Form 4 Link"] = cols[-1].find("a").attrs["href"]
             info_dict["Insider_id"] = cols[0].a["href"].split("oc=")[1].split("&tc=")[0]
-            df = df.append(info_dict, ignore_index=True)
+            frame.append(info_dict)
+        df = pd.DataFrame(frame)
         self.info["inside trader"] = df
         return df
 

--- a/finvizfinance/screener/overview.py
+++ b/finvizfinance/screener/overview.py
@@ -186,6 +186,7 @@ class Overview:
         if limit != -1:
             rows = rows[0:limit]
 
+        frame = []
         for row in rows:
             cols = row.findAll("td")[1:]
             info_dict = {}
@@ -195,8 +196,8 @@ class Overview:
                     info_dict[table_header[i]] = col.text
                 else:
                     info_dict[table_header[i]] = number_covert(col.text)
-            df = df.append(info_dict, ignore_index=True)
-        return df
+            frame.append(info_dict)
+        return pd.concat([df, pd.DataFrame(frame)], ignore_index=True)
 
     def _screener_helper(self, i, page, rows, df, num_col_index, table_header, limit):
         """Get screener table helper function.

--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -137,7 +137,7 @@ def scrap_function(url):
     table = soup.find("table", class_="table-light")
     rows = table.findAll("tr")
     table_header = [i.text.strip() for i in rows[0].findAll("td")][1:]
-    df = pd.DataFrame([], columns=table_header)
+    frame = []
     rows = rows[1:]
     num_col_index = [i for i in range(2, len(table_header))]
     for row in rows:
@@ -148,8 +148,8 @@ def scrap_function(url):
                 info_dict[table_header[i]] = col.text
             else:
                 info_dict[table_header[i]] = number_covert(col.text)
-        df = df.append(info_dict, ignore_index=True)
-    return df
+        frame.append(info_dict)
+    return pd.DataFrame(frame)
 
 
 def image_scrap_function(url, chart, timeframe, urlonly):


### PR DESCRIPTION
## Description

Resolves #55 

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code styling or code optimize

## What you did

Refactor calls to `df.append()` to use `pd.concat()` instead. To make this work, I have also delayed the creation of the `DataFrame` until after the loops are complete. This should be more efficient as well.

