### PR TITLE
Header fixed when using `screener_view` function

### DIFF
--- a/finvizfinance/group/custom.py
+++ b/finvizfinance/group/custom.py
@@ -82,7 +82,7 @@ class Custom(Overview):
         soup = web_scrap(self.url)
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
         frame = []
         rows = rows[1:]
         num_col_index = list(range(2, len(table_header)))

--- a/finvizfinance/group/custom.py
+++ b/finvizfinance/group/custom.py
@@ -82,7 +82,7 @@ class Custom(Overview):
         soup = web_scrap(self.url)
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.strip() for i in rows[0].findAll("td")][1:]
         frame = []
         rows = rows[1:]
         num_col_index = list(range(2, len(table_header)))

--- a/finvizfinance/group/overview.py
+++ b/finvizfinance/group/overview.py
@@ -94,7 +94,7 @@ class Overview:
         soup = web_scrap(self.url)
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
         frame = []
         rows = rows[1:]
         num_col_index = list(range(2, len(table_header)))

--- a/finvizfinance/group/overview.py
+++ b/finvizfinance/group/overview.py
@@ -28,7 +28,7 @@ class Overview:
 
         # group
         options = selects[0].findAll("option")
-        key = [i.text for i in options]
+        key = [i.text.strip() for i in options]
         value = []
         for option in options:
             temp = option["value"].split("?")[1].split("&")
@@ -41,7 +41,7 @@ class Overview:
 
         # order
         options = selects[1].findAll("option")
-        key = [i.text for i in options]
+        key = [i.text.strip() for i in options]
         value = [i["value"].split("&")[-1] for i in options]
         self.order_dict = dict(zip(key, value))
 
@@ -94,7 +94,7 @@ class Overview:
         soup = web_scrap(self.url)
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.strip() for i in rows[0].findAll("td")][1:]
         frame = []
         rows = rows[1:]
         num_col_index = list(range(2, len(table_header)))

--- a/finvizfinance/screener/custom.py
+++ b/finvizfinance/screener/custom.py
@@ -180,7 +180,7 @@ class Custom(Overview):
 
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
         num_col_index = [table_header.index(i) for i in table_header if i in NUMBER_COL]
         df = pd.DataFrame([], columns=table_header)
         if not select_page or select_page == 1:

--- a/finvizfinance/screener/custom.py
+++ b/finvizfinance/screener/custom.py
@@ -180,7 +180,7 @@ class Custom(Overview):
 
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.strip() for i in rows[0].findAll("td")][1:]
         num_col_index = [table_header.index(i) for i in table_header if i in NUMBER_COL]
         df = pd.DataFrame([], columns=table_header)
         if not select_page or select_page == 1:

--- a/finvizfinance/screener/overview.py
+++ b/finvizfinance/screener/overview.py
@@ -276,7 +276,7 @@ class Overview:
 
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.strip() for i in rows[0].findAll("td")][1:]
         num_col_index = [table_header.index(i) for i in table_header if i in NUMBER_COL]
         df = pd.DataFrame([], columns=table_header)
         if not select_page or select_page == 1:

--- a/finvizfinance/screener/overview.py
+++ b/finvizfinance/screener/overview.py
@@ -276,7 +276,7 @@ class Overview:
 
         table = soup.find("table", class_="table-light")
         rows = table.findAll("tr")
-        table_header = [i.text for i in rows[0].findAll("td")][1:]
+        table_header = [i.text.replace("\n\n", "") for i in rows[0].findAll("td")][1:]
         num_col_index = [table_header.index(i) for i in table_header if i in NUMBER_COL]
         df = pd.DataFrame([], columns=table_header)
         if not select_page or select_page == 1:


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Using `screener_view` function, headers had `\n\nName` and `\n\nTicker` in their data. This PR fixes that issue and future proofs it for any further changes in any columns.


## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## What you did

<!-- Please list the major changes in your PR. -->
`i.text` is replaced with `i.text.strip()` to ensure that there are no trailing `\n\n` in header names.

EDIT: Modified to use `strip()` in place of `replace()`.