### PR TITLE
Remove \n from columns in screener_view

### DIFF
--- a/finvizfinance/screener/custom.py
+++ b/finvizfinance/screener/custom.py
@@ -211,4 +211,8 @@ class Custom(Overview):
                 df = self._screener_helper(
                     i, page, rows, df, num_col_index, table_header, limit
                 )
+                
+        # Remove extra newline characters from the column Ticker
+        df.columns = df.columns.str.replace('\n', '')
+        
         return df

--- a/finvizfinance/screener/overview.py
+++ b/finvizfinance/screener/overview.py
@@ -306,6 +306,10 @@ class Overview:
                 df = self._screener_helper(
                     i, page, rows, df, num_col_index, table_header, limit
                 )
+        
+        # Remove extra newline characters from the column Ticker
+        df.columns = df.columns.str.replace('\n', '')
+        
         return df
 
     def compare(self, ticker, compare_list, order="ticker", verbose=1):


### PR DESCRIPTION
## Description

This PR addresses the issue of unwanted newline characters in the dataframe columns of screener_view in custom.py and overview.py files located in the screener folder. The newline characters are now removed from the columns.


## Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [-] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code styling or code optimize

## What you did

Removed the newline characters from the dataframe columns in screener_view of custom.py and overview.py files in the screener folder.

