### PR TITLE
[URGENT] added new method in screener/overview.py for paginated screener view

### DIFF
--- a/finvizfinance/screener/overview.py
+++ b/finvizfinance/screener/overview.py
@@ -185,7 +185,10 @@ class Overview:
             page_links = soup.find_all('a', class_='screener-pages')
             page_numbers = [link.text for link in page_links]
             return page_numbers[-1]
-        except:
+        except IndexError:
+            return 0
+        except Exception as e:
+            print(f"Error occurred: {str(e)}")
             return 0
 
     def _get_table(self, rows, df, num_col_index, table_header, limit=-1):

--- a/test/test_screener.py
+++ b/test/test_screener.py
@@ -1,16 +1,17 @@
 import pytest
 from finvizfinance.screener.overview import Overview
 
+
 def test_screener_overview():
     foverview = Overview()
     filters_dict = {'Exchange': 'AMEX', 'Sector': 'Basic Materials'}
     foverview.set_filter(filters_dict=filters_dict)
     df = foverview.screener_view(order="Company", ascend=False)
-    assert(df is not None)
+    assert (df is not None)
     ticker = 'TSLA'
     foverview.set_filter(signal='', filters_dict={}, ticker=ticker)
     df = foverview.screener_view()
-    assert(df is not None)
+    assert (df is not None)
 
 
 def test_screener_get_settings():
@@ -27,3 +28,17 @@ def test_screener_get_settings():
     with pytest.raises(ValueError):
         foverview.get_filter_options('Dummy')
 
+
+def test_paginated_screener_overview():
+    foverview = Overview()
+    filters_dict = {'Exchange': 'AMEX', 'Sector': 'Basic Materials'}
+    foverview.set_filter(filters_dict=filters_dict)
+    data = foverview.paginated_screener_view(
+        order="Company", ascend=False, page_no=2)
+    assert (data['df'] is not None)
+    assert (data['total_pages'] is not None)
+    ticker = 'TSLA'
+    foverview.set_filter(signal='', filters_dict={}, ticker=ticker)
+    data = foverview.paginated_screener_view()
+    assert (data['df'] is not None)
+    assert (data['total_pages'] is not None)


### PR DESCRIPTION
## Paginated Screener View

### Summary

This PR introduces a new feature called "Paginated Screener View" to the project. It allows retrieving paginated data for personal use by specifying the page number. The motivation behind this feature is to enable easier data retrieval in a controlled manner.

### Type of Change
- [x] New feature (non-breaking change which adds functionality)


### Details

The major changes included in this PR are:

- Added a new method named `paginated_screener_view` to handle paginated data retrieval.
- Created a supporting method to calculate the total count of pages.
- The `paginated_screener_view` method accepts a `page_no` parameter. If no page number is provided, it defaults to a specified value.
- The method returns a dictionary containing a DataFrame (`df`) of the screener information table and the total count of pages (`total_page_count`).

### Tests

- Added tests for the `paginated_screener_view` method to ensure its functionality and correctness. 
### Dependencies

No new dependencies are required for this change.

### Documentation

This change introduces a new feature, so the documentation needs to be updated accordingly to include details about the `paginated_screener_view` method and how to use it effectively.

Please review and merge this PR asap. If there are any further changes or improvements needed, kindly let me know.

Thank you!
