### PR TITLE
fixed limit not actually working in overview.py

### DIFF
--- a/finvizfinance/screener/overview.py
+++ b/finvizfinance/screener/overview.py
@@ -268,7 +268,7 @@ class Overview:
 
         if limit != -1:
             if page > (limit - 1) // 20 + 1:
-                page = (limit - 1) // 20 + 1
+                end_page = (limit - 1) // 20 + 1
 
         if verbose == 1:
             if not select_page:
@@ -291,7 +291,7 @@ class Overview:
                 sleep(sleep_sec)  # Adding sleep
                 if verbose == 1:
                     if not select_page:
-                        progress_bar(i + 1, page)
+                        progress_bar(i + 1, end_page)
                     else:
                         progress_bar(1, 1)
 


### PR DESCRIPTION
## Description

limit param for Overview screener would not work and scraper would grab all items. Now actually stops at closest multiple of 20 above limit as intended. No dependencies needed.

## Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## What you did

Updated logic to correctly limit number of pages to iterate scraper through if a limit is set. Also fixed progress bar to correctly display the page numbers as it scrapes.

