### PR TITLE
added cleanup for number_convert to address errors

### DIFF
--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -136,16 +136,17 @@ def image_scrap_function(url, chart, timeframe, urlonly):
 
 
 def number_covert(num):
-    """covert number(str) to number(float)
+    """Convert number(str) to number(float)
 
     Args:
-        num(str): number of string
+        num(str): number as a string
     Return:
-        num(float): number of string
+        num(float or None): number converted to float or None
     """
-    if num == "-":
+    if not num or num == "-":  # Check if the string is empty or is "-"
         return None
-    elif num[-1] == "%":
+    num = num.strip()  # Remove any surrounding whitespace
+    if num[-1] == "%":
         return float(num[:-1]) / 100
     elif num[-1] == "B":
         return float(num[:-1]) * 1000000000
@@ -154,7 +155,7 @@ def number_covert(num):
     elif num[-1] == "K":
         return float(num[:-1]) * 1000
     else:
-        return float("".join(num.split(",")))
+        return float(num.replace(",", ""))  # Remove commas and convert to float
 
 
 def format_datetime(date_str):


### PR DESCRIPTION
## Description

The Insider.get_insider function is failing in util.py with this error: 
 File "h:\anaconda3\lib\site-packages\finvizfinance\insider.py", line 88, in get_insider
    info_dict[table_header[i]] = number_covert(col.text)
  File "h:\anaconda3\lib\site-packages\finvizfinance\util.py", line 148, in number_covert
    elif num[-1] == "%":
IndexError: string index out of range

## Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## What you did
Changes Made:
* Empty String Check (if not num): This ensures that the code doesn't attempt to access num[-1] if num is empty.
* Stripping Whitespace (num = num.strip()): Removes any leading or trailing whitespace in the string, ensuring clean input.
* Replaced .split(",") with .replace(",", ""): This simplifies removing commas from the string, making it more efficient.

How This Fixes the Problem:
The if not num check ensures that the function won't try to access the last character of an empty string, thus avoiding the IndexError.
If num is "%", "B", "M", or "K", the function properly processes the string and converts it to the corresponding float.
If num is just a plain number with commas, it will remove the commas and convert the number to a float.

