### PR TITLE
Raise specific exception

### DIFF
--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -41,9 +41,9 @@ def web_scrap(url, params=None):
         website.raise_for_status()
         soup = BeautifulSoup(website.text, "lxml")
     except requests.exceptions.HTTPError as err:
-        raise Exception(err)
+        raise requests.exceptions.HTTPError(f"HTTP error for URL {url}: {err}")
     except requests.exceptions.Timeout as err:
-        raise Exception(err)
+        raise requests.exceptions.Timeout(f"Timeout for URL {url}: {err}")
     return soup
 
 


### PR DESCRIPTION
## Description
In case of an HTTPError or a Timeout the general exception of type "Exception" is raised.

However, using "Exception"  causes pylint tests to fail with:

"W0718: Catching too general exception Exception (broad-exception-caught"

This can be corrected by adding a specific exception in util.py

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Code styling or code optimize

## What you did

<!-- Please list the major changes in your PR. -->
Added a specific exception for HTTPError and Timeout
