### PR TITLE
fixed bugs when the secrutity has no news/inside trader

### DIFF
--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -277,6 +277,9 @@ class finvizfinance:
             df(pandas.DataFrame): news information table
         """
         fullview_news_outer = self.soup.find("table", class_="fullview-news-outer")
+        if fullview_news_outer is None:
+            self.info["news"] = None
+            return None
         rows = fullview_news_outer.find_all("tr")
         
         frame = []
@@ -312,6 +315,9 @@ class finvizfinance:
             df(pandas.DataFrame): insider information table
         """
         inside_trader = self.soup.find("table", class_="body-table")
+        if inside_trader is None:
+            self.info["inside trader"] = None
+            return None
         rows = inside_trader.find_all("tr")
         table_header = [i.text for i in rows[0].find_all("th")]
         table_header += ["SEC Form 4 Link", "Insider_id"]


### PR DESCRIPTION
## Description

When the security has no news or insider trade, get_all_info will throw an exception.


## Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## What you did
Added is none test after `soup.find()` for `ticker_inside_trader()` and `ticker_news()`