### PR TITLE
Adding new `ticker_peer` method to `quote.py` which extracts and returns peer tickers listed on the Finviz page for a given stock. This allows users to programmatically retrieve comparable tickers for analysis or comparison purposes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ stock_description = stock.ticker_description()
 # stock_description
 # stock_description = 'Tesla, Inc. designs, develops, manufactures, ...'
 ```
+#### Peer
+
+```python
+stock_peer = stock.ticker_peer()
+
+# stock_peer
+# stock_peer = ['LI', 'XPEV', 'NIO', 'RIVN', 'LCID', 'TM', 'HMC', 'GM', 'STLA', 'F']
+```
 
 #### Outer Ratings
 

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -227,6 +227,29 @@ class finvizfinance:
         """
         return self.soup.find("td", class_="fullview-profile").text
 
+    def ticker_peer(self):
+        """Get peer tickers for the given ticker.
+
+        Returns:
+            list: A list of peer ticker symbols (str). Returns an empty list if not found.
+        """
+        try:
+            peer_link = self.soup.find("a", string="Peers")
+            if not peer_link:
+                return []
+
+            href = peer_link.get("href", "")
+            if "t=" not in href:
+                return []
+
+            tickers_part = href.split("t=")[-1]
+            peers = [ticker.strip() for ticker in tickers_part.split(",") if ticker.strip()]
+            return peers
+
+        except Exception as e:
+            print(f"Error extracting ticker peers: {e}")
+            return []
+           
     def ticker_outer_ratings(self):
         """Get outer ratings table.
 

--- a/test/test_quote.py
+++ b/test/test_quote.py
@@ -37,3 +37,10 @@ def test_finvizfinance_finvizfinance_chart(mocker):
     finvizfinance('dummy').ticker_charts()
     image_scrap_mock.assert_called_with(
         'https://finviz.com/chart.ashx?t=dummy&ty=c&ta=1&p=d', 'dummy', '')
+
+def test_ticker_peer_returns_list():
+    stock = finvizfinance("AAPL")
+    peers = stock.ticker_peer()
+    assert isinstance(peers, list)
+    assert len(peers) > 0
+    assert all(isinstance(p, str) for p in peers)


### PR DESCRIPTION
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Code styling or code optimize
## Description
A new method named `ticker_peer()` was added to the `quote.py` module. This method allows peer ticker symbols to be extracted from the Finviz page of a specified stock. It enables programmatic access to comparable tickers for analysis and comparison.

- The `ticker_peer()` method was implemented to locate and parse the "Peers" hyperlink on the Finviz stock page.

- Ticker symbols were extracted from the query string and returned as a cleaned list.

- Error handling was added to ensure the method returns an empty list when no peers are available or the structure is invalid.

- A descriptive docstring was included to document the method's purpose and return type.

## Example:
When called for ticker _**AAPL**_, the following ticker peers list is returned:
`['ORCL', 'CRM', 'ADBE', 'IBM', 'GOOGL', 'PANW', 'AMZN', 'CSCO', 'NVDA', 'INTC']`

## Test:
The new `ticker_peer()` method was tested using `pytest` to ensure reliability and correctness. A test case was written to verify that the method returns a list of peer ticker symbols for a given stock (e.g., "AAPL"). The test confirmed that the return type is a list, that the list is not empty, and that all elements are strings. The test was executed successfully with no conflicts, and all assertions passed, confirming that the method behaves as expected under normal conditions.
