### PR TITLE
Fix insider trading URL by removing .ashx extension

### DIFF
--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -8,7 +8,7 @@
 import pandas as pd
 from finvizfinance.util import web_scrap, number_covert
 
-INSIDER_URL = "https://finviz.com/insidertrading.ashx"
+INSIDER_URL = "https://finviz.com/insidertrading"
 
 
 class Insider:

--- a/test/test_insider.py
+++ b/test/test_insider.py
@@ -10,30 +10,30 @@ def test_finvizfinance_insider():
 def test_finvizfinance_insider_option(mocker):
     web_scrap_mock = mocker.patch('finvizfinance.insider.web_scrap', return_value="dummy web scrap")
     Insider()
-    web_scrap_mock.assert_called_with('https://finviz.com/insidertrading.ashx')
+    web_scrap_mock.assert_called_with('https://finviz.com/insidertrading')
     Insider('latest buys')
-    web_scrap_mock.assert_called_with('https://finviz.com/insidertrading.ashx?tc=1')
+    web_scrap_mock.assert_called_with('https://finviz.com/insidertrading?tc=1')
     Insider('latest sales')
-    web_scrap_mock.assert_called_with('https://finviz.com/insidertrading.ashx?tc=2')
+    web_scrap_mock.assert_called_with('https://finviz.com/insidertrading?tc=2')
     Insider('top week')
     web_scrap_mock.assert_called_with(
-        'https://finviz.com/insidertrading.ashx?or=-10&tv=100000&tc=7&o=-transactionValue')
+        'https://finviz.com/insidertrading?or=-10&tv=100000&tc=7&o=-transactionValue')
     Insider('top week buys')
     web_scrap_mock.assert_called_with(
-        'https://finviz.com/insidertrading.ashx?or=-10&tv=100000&tc=1&o=-transactionValue')
+        'https://finviz.com/insidertrading?or=-10&tv=100000&tc=1&o=-transactionValue')
     Insider('top week sales')
     web_scrap_mock.assert_called_with(
-        'https://finviz.com/insidertrading.ashx?or=-10&tv=100000&tc=2&o=-transactionValue')
+        'https://finviz.com/insidertrading?or=-10&tv=100000&tc=2&o=-transactionValue')
     Insider('top owner trade')
     web_scrap_mock.assert_called_with(
-        'https://finviz.com/insidertrading.ashx?or=10&tv=1000000&tc=7&o=-transactionValue')
+        'https://finviz.com/insidertrading?or=10&tv=1000000&tc=7&o=-transactionValue')
     Insider('top owner buys')
     web_scrap_mock.assert_called_with(
-        'https://finviz.com/insidertrading.ashx?or=10&tv=1000000&tc=1&o=-transactionValue')
+        'https://finviz.com/insidertrading?or=10&tv=1000000&tc=1&o=-transactionValue')
     Insider('top owner sales')
     web_scrap_mock.assert_called_with(
-        'https://finviz.com/insidertrading.ashx?or=10&tv=1000000&tc=2&o=-transactionValue')
+        'https://finviz.com/insidertrading?or=10&tv=1000000&tc=2&o=-transactionValue')
     insider_id = '1234'
     Insider(insider_id)
     web_scrap_mock.assert_called_with(
-        'https://finviz.com/insidertrading.ashx?oc=' + insider_id + '&tc=7')
+        'https://finviz.com/insidertrading?oc=' + insider_id + '&tc=7')


### PR DESCRIPTION
   Finviz changed their URL structure and no longer uses the .ashx extension for insider trading pages. This was causing 404 errors for all insider trading queries.

   Changes:
   - Updated INSIDER_URL from insidertrading.ashx to insidertrading
   - Updated test with the new URL format

- [ ] Bug fix (non-breaking change which fixes an issue)