### PR TITLE
Replace findAll with find_all for consistency

### DIFF
--- a/finvizfinance/screener/base.py
+++ b/finvizfinance/screener/base.py
@@ -102,7 +102,7 @@ class Base:
     def _get_page(self, soup):
         """Check the page number"""
         try:
-            options = soup.find(id="pageSelect").findAll("option")
+            options = soup.find(id="pageSelect").find_all("option")
             return len(options)
         except:
             return 0
@@ -119,7 +119,7 @@ class Base:
 
         frame = []
         for row in rows:
-            cols = row.findAll("td")[1:]
+            cols = row.find_all("td")[1:]
             info_dict = {}
             for i, col in enumerate(cols):
                 # check if the col is number
@@ -136,8 +136,8 @@ class Base:
     @staticmethod
     def _parse_table_header(soup):
         table = soup.find("table", class_="screener_table")
-        rows = table.findAll("tr")
-        table_headers = [i.text.strip() for i in rows[0].findAll("th")][1:]
+        rows = table.find_all("tr")
+        table_headers = [i.text.strip() for i in rows[0].find_all("th")][1:]
         return table_headers
 
     def _parse_table(self, df, soup, limit):


### PR DESCRIPTION
Fix findAll type

## Description

Hello! Updated the deprecated findAll BeautifulSoup syntax to the modern find_all across the screener modules to clear the terminal warnings in Python 3.10+

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code styling or code optimize

## What you did

<!-- Please list the major changes in your PR. -->

changed all findAll commands in screener/base.py to find_all to clear/fix the depreciated value warnings (they are cluttering the output of my code.)