### PR TITLE
fix(parser): update html parsing selector

### DIFF
--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -145,8 +145,7 @@ class finvizfinance:
         links = quote_links.find_all("a")
         fundament_info["Sector"] = links[0].text
         fundament_info["Industry"] = links[1].text
-        fundament_info["Country"] = links[2].text
-        #if fundament_info["Industry"] == "Exchange Traded Fund":             
+        fundament_info["Country"] = links[2].text          
         if len(links) < 5:
             fundament_info["Cap"] = ""
             fundament_info["Exchange"] = links[3].text
@@ -156,7 +155,7 @@ class finvizfinance:
   
 
 
-        fundament_table = self.soup.find("table", class_="snapshot-table2")
+        fundament_table = self.soup.find("div", class_="screener_snapshot-table-wrapper")
         rows = fundament_table.find_all("tr")
 
         for row in rows:

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -141,12 +141,20 @@ class finvizfinance:
         fundament_info["Company"] = self.soup.find(
             "h2", class_="quote-header_ticker-wrapper_company"
         ).text.strip()
-        quote_links = self.soup.find("div", class_="quote-links")
+        quote_links = self.soup.find("div", class_="quote-header_categories")
         links = quote_links.find_all("a")
         fundament_info["Sector"] = links[0].text
         fundament_info["Industry"] = links[1].text
         fundament_info["Country"] = links[2].text
-        fundament_info["Exchange"] = links[3].text
+        #if fundament_info["Industry"] == "Exchange Traded Fund":             
+        if len(links) < 5:
+            fundament_info["Cap"] = ""
+            fundament_info["Exchange"] = links[3].text
+        else:
+            fundament_info["Cap"] = links[3].text
+            fundament_info["Exchange"] = links[4].text
+  
+
 
         fundament_table = self.soup.find("table", class_="snapshot-table2")
         rows = fundament_table.find_all("tr")


### PR DESCRIPTION
## Description

A recent website update changed the ticker quote class from 'quote-links' to 'quote-header_categories'. 
This caused the parser to crash.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Solution

Updated the element selector and updated behaviour to correctly handle Exchange Traded Fund tickers,
which return 4 links instead of 5.

Closes #154
Closes #156
