### PR TITLE
fix(screener): ticker text doubled due to Finviz HTML change

### DIFF
--- a/finvizfinance/screener/base.py
+++ b/finvizfinance/screener/base.py
@@ -118,12 +118,25 @@ class Base:
             rows = rows[0:limit]
 
         frame = []
+        ticker_col = table_header.index("Ticker") if "Ticker" in table_header else -1
         for row in rows:
             cols = row.findAll("td")[1:]
             info_dict = {}
             for i, col in enumerate(cols):
-                # check if the col is number
-                if i not in num_col_index:
+                # Finviz wraps the ticker in two <a> tags (company-ticker with
+                # logo + tab-link), so col.text returns the ticker doubled.
+                # Extract the real ticker from the href query parameter instead.
+                if i == ticker_col:
+                    a_tag = col.find("a", class_="company-ticker")
+                    if a_tag:
+                        href = a_tag.get("href", "")
+                        if "t=" in href:
+                            info_dict[table_header[i]] = href.split("t=")[1].split("&")[0]
+                        else:
+                            info_dict[table_header[i]] = a_tag.get_text(strip=True)
+                    else:
+                        info_dict[table_header[i]] = col.text
+                elif i not in num_col_index:
                     info_dict[table_header[i]] = col.text
                 else:
                     info_dict[table_header[i]] = number_covert(col.text)


### PR DESCRIPTION
## Problem

Finviz recently updated their screener HTML. The Ticker cell now contains **two `<a>` tags**:

1. `<a class="company-ticker">` — contains a logo `<img>` and a `<span>` with the ticker
2. `<a class="tab-link">` — contains the ticker as plain text

Because `col.text` concatenates all text content, **every ticker is returned doubled**:
- `AAPL` → `AAAPL`
- `MSFT` → `MMSFT`  
- `SEZL` → `SSEZL`
- `A` (Agilent) → `AA`

This affects all screener views (overview, performance, valuation, etc.).

### Reproducing

```python
from finvizfinance.screener.overview import Overview

fover = Overview()
fover.set_filter(filters_dict={'Market Cap.': '+Small (over $300mln)'})
df = fover.screener_view(limit=20)
print(df['Ticker'].tolist())
# ['AA', 'AAAL', 'AAAMI', 'AAAPL', ...]  ← all doubled
```

### Root cause

In `screener/base.py`, `_get_table()` uses `col.text` for all columns. With two `<a>` tags in the Ticker cell, `.text` returns the ticker twice.

Raw HTML of a ticker cell:
```html
<td>
  <span class="flex items-center gap-1 pl-0.5">
    <a class="company-ticker" href="stock?t=AAPL&ty=c&p=d&b=1">
      <img alt="AAPL logo" src="..."><span>AAPL</span>
    </a>
    <a class="tab-link" href="stock?t=AAPL&ty=c&p=d&b=1">AAPL</a>
  </span>
</td>
```

## Fix

For the Ticker column specifically, extract the ticker from the `href` query parameter (`?t=TICKER`) of the `company-ticker` anchor instead of using `col.text`. This is robust against future HTML changes since the href is the canonical source.

## Testing

Verified against live Finviz data — all tickers now return correctly (`AAPL`, `MSFT`, `A`, etc.).