### PR TITLE
Fix duplicate first letter in ticker column

### DIFF
--- a/finvizfinance/screener/base.py
+++ b/finvizfinance/screener/base.py
@@ -124,7 +124,10 @@ class Base:
             for i, col in enumerate(cols):
                 # check if the col is number
                 if i not in num_col_index:
-                    info_dict[table_header[i]] = col.text
+                    if table_header[i] == "Ticker" and col.has_attr("data-boxover-ticker"):
+                        info_dict[table_header[i]] = col["data-boxover-ticker"]
+                    else:
+                        info_dict[table_header[i]] = col.text
                 else:
                     info_dict[table_header[i]] = number_covert(col.text)
             frame.append(info_dict)


### PR DESCRIPTION
## Description
The screener was returning tickers with a duplicated first letter (e.g. AAPL came out as AAAPL, ABNB as AABNB).

Finviz now renders a hidden <span> with the ticker's first letter inside the logo link. Reading the full cell text picked up both that hidden letter and the real ticker, producing the duplicate.

The fix reads the clean value from the `data-boxover-ticker` data attribute on the Ticker cell instead of the full cell text. All other columns are unchanged.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## What you did
- Updated `_get_table` in `finvizfinance/screener/base.py` to read the Ticker column from the `data-boxover-ticker` attribute when present, falling back to cell text otherwise.
- Verified locally: tickers now return clean (e.g. ZYME, AAPL) with no duplicated first letter.