### PR TITLE
fix: support current calendar and futures markup

### DIFF
--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -5,6 +5,7 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+import json
 import re
 import pandas as pd
 from finvizfinance.util import web_scrap, warn_missing
@@ -13,28 +14,68 @@ from finvizfinance.exceptions import FinvizParseError
 CALENDAR_URL = "https://finviz.com/calendar.ashx"
 
 
+def _script_json(soup, function_name):
+    """Extract the JSON argument passed to a client-side init function."""
+    marker = re.compile(r"(?:window\.)?{}\s*\(".format(re.escape(function_name)))
+    for script in soup.find_all("script"):
+        text = script.string or script.get_text()
+        match = marker.search(text)
+        if match is None:
+            continue
+        start = match.end()
+        decoder = json.JSONDecoder()
+        try:
+            data, _ = decoder.raw_decode(text[start:].lstrip())
+        except (json.JSONDecodeError, TypeError):
+            raise FinvizParseError(url=CALENDAR_URL, selector="script: {}(...)".format(function_name))
+        if isinstance(data, list):
+            return data
+    return None
+
+
 class Calendar:
-    """Calendar
-    Getting information from the finviz calendar page.
-    """
+    """Getting information from the finviz calendar page."""
 
     def __init__(self):
-        """initiate module"""
         pass
 
     def calendar(self):
-        """Get economic calendar table.
-
-        Returns:
-            df(pandas.DataFrame): economic calendar table
-        """
+        """Get economic calendar table."""
         soup = web_scrap(CALENDAR_URL)
         tables = soup.find_all("table", class_="calendar")
-        if not tables:
-            # A missing calendar table is a Structural break (Drift), not an
-            # empty result — surface it instead of silently returning [].
-            raise FinvizParseError(url=CALENDAR_URL, selector="table.calendar")
+        if tables:
+            return self._calendar_tables(tables)
 
+        data = _script_json(soup, "FinvizInitCalendar")
+        if data is None:
+            raise FinvizParseError(url=CALENDAR_URL, selector="table.calendar or FinvizInitCalendar")
+        return pd.DataFrame([self._calendar_row(row) for row in data])
+
+    @staticmethod
+    def _calendar_row(row):
+        """Normalize a client-rendered calendar object to the public columns."""
+        def value(*keys):
+            for key in keys:
+                if key in row:
+                    return row[key]
+            return None
+
+        day = value("date", "day")
+        time = value("time", "datetime")
+        if time is not None and day is not None and time != day:
+            day = "{}, {}".format(day, time)
+        return {
+            "Datetime": day,
+            "Release": value("release", "event", "title"),
+            "Impact": value("impact", "importance"),
+            "For": value("for", "period"),
+            "Actual": value("actual"),
+            "Expected": value("expected", "estimate"),
+            "Prior": value("prior", "previous"),
+        }
+
+    @staticmethod
+    def _calendar_tables(tables):
         frame = []
         for table in tables:
             rows = table.find_all("tr")
@@ -43,7 +84,6 @@ class Calendar:
             check_cols = rows[1].find_all("td")
             if len(check_cols) < 3 or check_cols[2].text == "No economic releases":
                 continue
-            # parse date
             date = rows[0].find("td").text
             for row in rows[1:]:
                 cols = row.find_all("td")
@@ -55,17 +95,8 @@ class Calendar:
                     match = re.findall(r"gfx/calendar/impact_(.*).gif", img["src"])
                     impact = match[0] if match else None
                 if impact is None:
-                    # Missing field: keep None but surface it (Missing-field
-                    # semantics), rather than silently dropping the signal.
                     warn_missing(CALENDAR_URL, "calendar impact icon")
-                info_dict = {
-                    "Datetime": "{}, {}".format(date, cols[0].text),
-                    "Release": cols[2].text,
-                    "Impact": impact,
-                    "For": cols[4].text,
-                    "Actual": cols[5].text,
-                    "Expected": cols[6].text,
-                    "Prior": cols[7].text,
-                }
-                frame.append(info_dict)
+                frame.append({"Datetime": "{}, {}".format(date, cols[0].text), "Release": cols[2].text,
+                              "Impact": impact, "For": cols[4].text, "Actual": cols[5].text,
+                              "Expected": cols[6].text, "Prior": cols[7].text})
         return pd.DataFrame(frame)

--- a/finvizfinance/future.py
+++ b/finvizfinance/future.py
@@ -6,6 +6,7 @@
 """
 
 import json
+import re
 import pandas as pd
 from finvizfinance.util import web_scrap
 from finvizfinance.exceptions import FinvizParseError
@@ -13,24 +14,35 @@ from finvizfinance.exceptions import FinvizParseError
 FUTURES_URL = "https://finviz.com/futures_performance.ashx"
 
 
+def _extract_rows(soup):
+    """Extract rows from either the legacy or current init call."""
+    html = soup.prettify()
+    patterns = [
+        r"var\s+rows\s*=\s*",
+        r"(?:window\.)?FinvizInitFuturesPerformance\s*\(\s*",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, html)
+        if match is None:
+            continue
+        try:
+            data, _ = json.JSONDecoder().raw_decode(html[match.end():].lstrip())
+        except json.JSONDecodeError:
+            raise FinvizParseError(url=FUTURES_URL, selector="futures performance JSON")
+        if pattern.startswith("var"):
+            return data
+        return data
+    raise FinvizParseError(url=FUTURES_URL, selector="futures performance JSON")
+
+
 class Future:
-    """Future
-    Getting information from the finviz future page.
-    """
+    """Getting information from the finviz future page."""
 
     def __init__(self):
-        """initiate module"""
         pass
 
     def performance(self, timeframe="D"):
-        """Get forex performance table.
-
-        Args:
-            timeframe (str): choice of timeframe(D, W, M, Q, HY, Y)
-
-        Returns:
-            df(pandas.DataFrame): forex performance table
-        """
+        """Get futures performance table."""
         timeframe_dict = {"W": 12, "M": 13, "Q": 14, "HY": 15, "Y": 16}
         params = {}
         if timeframe in timeframe_dict:
@@ -39,16 +51,4 @@ class Future:
             raise ValueError("Invalid timeframe '{}'".format(timeframe))
 
         soup = web_scrap(FUTURES_URL, params)
-
-        html = soup.prettify()
-        start_marker = "var rows = "
-        end_marker = "FinvizInitFuturesPerformance(rows);"
-        if start_marker not in html or end_marker not in html:
-            raise FinvizParseError(
-                url=FUTURES_URL,
-                selector="script: var rows = ... FinvizInitFuturesPerformance",
-            )
-        data = html[html.find(start_marker) + len(start_marker) : html.find(end_marker)]
-        data = json.loads(data.strip()[:-1])
-        df = pd.DataFrame(data)
-        return df
+        return pd.DataFrame(_extract_rows(soup))

--- a/test/fixtures/calendar_current.html
+++ b/test/fixtures/calendar_current.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html><body>
+<script>
+window.FinvizInitCalendar([{"date":"Mon Aug 26","time":"08:30 AM","release":"GDP Growth Rate","impact":"3","for":"Q2","actual":"3.0%","expected":"2.8%","prior":"2.5%"}]);
+</script>
+</body></html>

--- a/test/fixtures/futures_current.html
+++ b/test/fixtures/futures_current.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html><body>
+<script>
+window.FinvizInitFuturesPerformance([{"ticker":"ES","label":"S&P 500","group":"Index","perf":{"day":0.5,"week":1.2}}, {"ticker":"NQ","label":"Nasdaq 100","group":"Index","perf":{"day":-0.3,"week":0.8}}]);
+</script>
+</body></html>

--- a/test/test_calendar.py
+++ b/test/test_calendar.py
@@ -11,18 +11,27 @@ from conftest import use_session, html_response, blocked_response
 def test_calendar_real():
     use_session(html_response("calendar.html"))
     df = Calendar().calendar()
-    # The second table ("No economic releases") is skipped -> 2 rows remain.
     assert len(df) == 2
     assert df.iloc[0]["Release"] == "GDP Growth Rate"
     assert df.iloc[0]["Impact"] == "3"
     assert df.iloc[0]["Datetime"].startswith("Mon Aug 26")
 
 
+def test_calendar_current_client_rendered_format():
+    use_session(html_response("calendar_current.html"))
+    df = Calendar().calendar()
+    assert df.to_dict("records") == [{
+        "Datetime": "Mon Aug 26, 08:30 AM", "Release": "GDP Growth Rate",
+        "Impact": "3", "For": "Q2", "Actual": "3.0%",
+        "Expected": "2.8%", "Prior": "2.5%",
+    }]
+
+
 def test_calendar_drift_raises_parse_error_not_silent_empty():
     use_session(html_response("calendar_drift.html"))
     with pytest.raises(FinvizParseError) as exc:
         Calendar().calendar()
-    assert exc.value.selector == "table.calendar"
+    assert exc.value.selector == "table.calendar or FinvizInitCalendar"
 
 
 def test_calendar_wall_raises_blocked_error():

--- a/test/test_future.py
+++ b/test/test_future.py
@@ -1,4 +1,4 @@
-"""Offline fixture tests for the future scraper (previously untested)."""
+"""Offline fixture tests for the future scraper."""
 
 import pytest
 
@@ -13,6 +13,13 @@ def test_future_real():
     df = Future().performance()
     assert not df.empty
     assert list(df["ticker"]) == ["ES", "NQ"]
+
+
+def test_future_current_client_rendered_format():
+    use_session(html_response("futures_current.html"))
+    df = Future().performance()
+    assert list(df["ticker"]) == ["ES", "NQ"]
+    assert list(df["perf"])[0]["day"] == 0.5
 
 
 def test_future_timeframe_param():


### PR DESCRIPTION
## Summary

Follow-up to #160 that fixes the two live parser failures identified by its smoke test:

- Support client-rendered calendar JSON while retaining legacy table parsing.
- Support current `FinvizInitFuturesPerformance([...])` payloads while retaining legacy futures parsing.
- Add deterministic fixtures and regression tests for both formats.

## Validation

- `./venv/bin/pytest test` — 87 passed
- `./venv/bin/python -m compileall -q finvizfinance scripts` — passed
- `git diff --check` — passed

Closes the production parser issues reported in #160.