### PR TITLE
fix: raise FinvizParseError when client-rendered calendar fields drift

### DIFF
--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -49,7 +49,13 @@ class Calendar:
         data = _script_json(soup, "FinvizInitCalendar")
         if data is None:
             raise FinvizParseError(url=CALENDAR_URL, selector="table.calendar or FinvizInitCalendar")
-        return pd.DataFrame([self._calendar_row(row) for row in data])
+        rows = [self._calendar_row(row) for row in data if isinstance(row, dict)]
+        # A non-empty payload that yields no readable values means finviz
+        # renamed the JSON fields (Drift). Surface it instead of returning an
+        # all-None table that would silently pass the live smoke check.
+        if data and not any(value is not None for row in rows for value in row.values()):
+            raise FinvizParseError(url=CALENDAR_URL, selector="FinvizInitCalendar fields")
+        return pd.DataFrame(rows)
 
     @staticmethod
     def _calendar_row(row):

--- a/test/fixtures/calendar_current_empty.html
+++ b/test/fixtures/calendar_current_empty.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html><body>
+<script>
+window.FinvizInitCalendar([]);
+</script>
+</body></html>

--- a/test/fixtures/calendar_current_unknown_keys.html
+++ b/test/fixtures/calendar_current_unknown_keys.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html><body>
+<script>
+window.FinvizInitCalendar([{"foo":"Mon Aug 26","bar":"GDP Growth Rate","baz":"3"}]);
+</script>
+</body></html>

--- a/test/test_calendar.py
+++ b/test/test_calendar.py
@@ -27,6 +27,23 @@ def test_calendar_current_client_rendered_format():
     }]
 
 
+def test_calendar_current_unknown_keys_raise_parse_error():
+    # finviz keeps the FinvizInitCalendar call but renames every field -> the
+    # normalized rows are all-None. That is Drift, not data; it must raise
+    # instead of returning a table of Nones the live smoke check waves through.
+    use_session(html_response("calendar_current_unknown_keys.html"))
+    with pytest.raises(FinvizParseError) as exc:
+        Calendar().calendar()
+    assert exc.value.selector == "FinvizInitCalendar fields"
+
+
+def test_calendar_current_empty_list_returns_empty_frame():
+    # An empty calendar day is a legitimate empty result, not Drift.
+    use_session(html_response("calendar_current_empty.html"))
+    df = Calendar().calendar()
+    assert df.empty
+
+
 def test_calendar_drift_raises_parse_error_not_silent_empty():
     use_session(html_response("calendar_drift.html"))
     with pytest.raises(FinvizParseError) as exc:


### PR DESCRIPTION
## Summary

Follow-up hardening for the calendar client-rendered path added in #160 (stacked onto `reliability-overhaul`, same as #161).

`Calendar.calendar()` parses the `FinvizInitCalendar([...])` JSON by mapping a **fixed set of field names** (`date`/`release`/`impact`/...). If finviz renames those fields, `_calendar_row` normalizes every column to `None` and the method returns a **DataFrame full of `None`s**. That is worse than a hard failure: `scripts/live_smoke.py` only classifies an endpoint as DRIFT when it *raises*, so an all-`None` table would be reported as **OK** and the drift would go unnoticed.

## What changed

- `Calendar.calendar()` now raises `FinvizParseError(selector="FinvizInitCalendar fields")` when a **non-empty** payload yields no readable values (i.e. finviz changed the field names → Drift).
- A legitimately **empty** calendar (`FinvizInitCalendar([])`) still returns an empty DataFrame — empty is not drift.
- Non-dict rows are ignored defensively.

No public API change; the happy path (recognized fields) is unchanged.

## Testing

- `test_calendar_current_unknown_keys_raise_parse_error` — renamed fields → `FinvizParseError`.
- `test_calendar_current_empty_list_returns_empty_frame` — empty list → empty frame, no raise.
- `pytest test` → **89 passed** (offline, no network).