### PR TITLE
refactor: drop redundant branch in future _extract_rows

### DIFF
--- a/finvizfinance/future.py
+++ b/finvizfinance/future.py
@@ -29,8 +29,6 @@ def _extract_rows(soup):
             data, _ = json.JSONDecoder().raw_decode(html[match.end():].lstrip())
         except json.JSONDecodeError:
             raise FinvizParseError(url=FUTURES_URL, selector="futures performance JSON")
-        if pattern.startswith("var"):
-            return data
         return data
     raise FinvizParseError(url=FUTURES_URL, selector="futures performance JSON")
 


### PR DESCRIPTION
## Summary

Follow-up cleanup for the futures parser added in #160 (stacked onto `reliability-overhaul`).

In `future._extract_rows`, both arms of the `if pattern.startswith("var")` check returned `data`, so the conditional was dead code. Collapsed to a single `return data`.

## What changed

- Removed the redundant `if pattern.startswith("var"): return data` branch in `finvizfinance/future.py`. No behavior change.

## Testing

- Both formats stay covered: `test_future_real` (legacy `var rows = [...]`) and `test_future_current_client_rendered_format` (`FinvizInitFuturesPerformance([...])`).
- `pytest test` → **89 passed** (offline, no network).