### PR TITLE
feat(quote): expose statement reporting currency

### DIFF
--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -487,6 +487,8 @@ class Statements:
             website.raise_for_status()
             response = json.loads(website.content)
             df = pd.DataFrame.from_dict(response["data"], orient="index")
+            currency = response.get("currency")
+            df.columns.name = f"Currency: {currency}"
             return df
         except requests.exceptions.HTTPError as err:
             raise Exception(err)

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -521,7 +521,8 @@ class Statements:
             statement(str): I(Income Statement), B(Balace Sheet), C(Cash Flow)
             timeframe(str): A(Annual), Q(Quarter)
         Returns:
-            df(pandas.DataFrame): statements table
+            df(pandas.DataFrame): statements table. The reporting currency (e.g.
+                "USD") is stored in ``df.attrs["currency"]``.
         """
         url = "https://finviz.com/api/statement.ashx?t={ticker}&s={statement}{timeframe}".format(
             ticker=ticker, statement=statement, timeframe=timeframe
@@ -530,6 +531,11 @@ class Statements:
         if "data" not in response:
             raise FinvizParseError(url=url, selector="json:data")
         df = pd.DataFrame.from_dict(response["data"], orient="index")
+        # Expose the reporting currency finviz returns (e.g. "USD"). The raw code
+        # lives in df.attrs for programmatic access; when present it is also shown
+        # as the column-axis label so it renders above the statement columns.
         currency = response.get("currency")
-        df.columns.name = f"Currency: {currency}"
+        df.attrs["currency"] = currency
+        if currency:
+            df.columns.name = f"Currency: {currency}"
         return df

--- a/test/test_quote.py
+++ b/test/test_quote.py
@@ -152,10 +152,23 @@ def test_ticker_charts_invalid_timeframe():
 
 
 def test_statements_real():
-    use_session(FakeResponse(content=b'{"data": {"2023": {"Revenue": "100"}}}'))
+    use_session(
+        FakeResponse(content=b'{"currency": "USD", "data": {"2023": {"Revenue": "100"}}}')
+    )
     df = Statements().get_statements("AAPL")
     assert df is not None
     assert not df.empty
+    # currency is exposed idiomatically in attrs, and labelled on the column axis
+    assert df.attrs["currency"] == "USD"
+    assert df.columns.name == "Currency: USD"
+
+
+def test_statements_currency_missing_is_none_and_unlabelled():
+    # finviz may omit currency; we must not render a misleading "Currency: None".
+    use_session(FakeResponse(content=b'{"data": {"2023": {"Revenue": "100"}}}'))
+    df = Statements().get_statements("AAPL")
+    assert df.attrs["currency"] is None
+    assert df.columns.name is None
 
 
 def test_statements_wall_raises_blocked_error():


### PR DESCRIPTION
## Summary

Merges [#148](https://github.com/lit26/finvizfinance/pull/148) (by @longtu290) onto `develop` and improves on it.

PR #148 surfaced the reporting currency finviz returns from the statement API, but was written against the old `requests`/`json.loads` transport and did not apply to `develop`'s refactored `web_scrap_json` + `FinvizParseError` path. This brings it in (real merge, preserving the contributor's commit) and hardens it.

### Changes

**`finvizfinance/quote.py` — `Statements.get_statements`**
- Stores the raw currency code in `df.attrs["currency"]` for idiomatic programmatic access (e.g. `"USD"`).
- Only labels the column axis (`df.columns.name = "Currency: <code>"`) when currency is present, so a missing field no longer renders the misleading `Currency: None`.

**`test/test_quote.py`**
- `test_statements_real` now asserts both `df.attrs["currency"]` and `df.columns.name`.
- New `test_statements_currency_missing_is_none_and_unlabelled` guards the missing-field case.

### Validation

- Full offline suite: `92 passed` (bare `pytest test`, matches CI).
- Live end-to-end (AAPL): `df.attrs['currency']=='USD'`, `df.columns.name=='Currency: USD'`, shape 31×9.

Closes #148.