### PR TITLE
style: adopt ruff (lint + format) and pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# Ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.4
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Downloads](https://pepy.tech/badge/finvizfinance)](https://pepy.tech/project/finvizfinance)
 [![CodeFactor](https://www.codefactor.io/repository/github/lit26/finvizfinance/badge/master)](https://www.codefactor.io/repository/github/lit26/finvizfinance/overview/master)
 [![Donate PayPal](https://img.shields.io/badge/Donate%20%24-PayPal-brightgreen.svg)](https://www.paypal.me/TIANNINGL/)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 # finvizfinance
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,34 +9,33 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath('../../'))
+sys.path.insert(0, os.path.abspath("../../"))
 
-project = 'finvizfinance'
-copyright = '2024, Tianning Li'
-author = 'Tianning Li'
+project = "finvizfinance"
+copyright = "2024, Tianning Li"
+author = "Tianning Li"
 # The full version, including alpha/beta/rc tags
-release = '1.4.0'
+release = "1.4.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.napoleon"]
 
 napoleon_google_docstring = True
 napoleon_use_param = False
 napoleon_use_ivar = True
 
 
-templates_path = ['_templates']
-exclude_patterns = ['build', 'Thumbs.db', '.DS_Store']
-
+templates_path = ["_templates"]
+exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"

--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -7,16 +7,18 @@
 
 import json
 import re
+
 import pandas as pd
-from finvizfinance.util import web_scrap, warn_missing
+
 from finvizfinance.exceptions import FinvizParseError
+from finvizfinance.util import warn_missing, web_scrap
 
 CALENDAR_URL = "https://finviz.com/calendar.ashx"
 
 
 def _script_json(soup, function_name):
     """Extract the JSON argument passed to a client-side init function."""
-    marker = re.compile(r"(?:window\.)?{}\s*\(".format(re.escape(function_name)))
+    marker = re.compile(rf"(?:window\.)?{re.escape(function_name)}\s*\(")
     for script in soup.find_all("script"):
         text = script.string or script.get_text()
         match = marker.search(text)
@@ -26,8 +28,10 @@ def _script_json(soup, function_name):
         decoder = json.JSONDecoder()
         try:
             data, _ = decoder.raw_decode(text[start:].lstrip())
-        except (json.JSONDecodeError, TypeError):
-            raise FinvizParseError(url=CALENDAR_URL, selector="script: {}(...)".format(function_name))
+        except (json.JSONDecodeError, TypeError) as err:
+            raise FinvizParseError(
+                url=CALENDAR_URL, selector=f"script: {function_name}(...)"
+            ) from err
         if isinstance(data, list):
             return data
     return None
@@ -48,18 +52,25 @@ class Calendar:
 
         data = _script_json(soup, "FinvizInitCalendar")
         if data is None:
-            raise FinvizParseError(url=CALENDAR_URL, selector="table.calendar or FinvizInitCalendar")
+            raise FinvizParseError(
+                url=CALENDAR_URL, selector="table.calendar or FinvizInitCalendar"
+            )
         rows = [self._calendar_row(row) for row in data if isinstance(row, dict)]
         # A non-empty payload that yields no readable values means finviz
         # renamed the JSON fields (Drift). Surface it instead of returning an
         # all-None table that would silently pass the live smoke check.
-        if data and not any(value is not None for row in rows for value in row.values()):
-            raise FinvizParseError(url=CALENDAR_URL, selector="FinvizInitCalendar fields")
+        if data and not any(
+            value is not None for row in rows for value in row.values()
+        ):
+            raise FinvizParseError(
+                url=CALENDAR_URL, selector="FinvizInitCalendar fields"
+            )
         return pd.DataFrame(rows)
 
     @staticmethod
     def _calendar_row(row):
         """Normalize a client-rendered calendar object to the public columns."""
+
         def value(*keys):
             for key in keys:
                 if key in row:
@@ -69,7 +80,7 @@ class Calendar:
         day = value("date", "day")
         time = value("time", "datetime")
         if time is not None and day is not None and time != day:
-            day = "{}, {}".format(day, time)
+            day = f"{day}, {time}"
         return {
             "Datetime": day,
             "Release": value("release", "event", "title"),
@@ -102,7 +113,15 @@ class Calendar:
                     impact = match[0] if match else None
                 if impact is None:
                     warn_missing(CALENDAR_URL, "calendar impact icon")
-                frame.append({"Datetime": "{}, {}".format(date, cols[0].text), "Release": cols[2].text,
-                              "Impact": impact, "For": cols[4].text, "Actual": cols[5].text,
-                              "Expected": cols[6].text, "Prior": cols[7].text})
+                frame.append(
+                    {
+                        "Datetime": f"{date}, {cols[0].text}",
+                        "Release": cols[2].text,
+                        "Impact": impact,
+                        "For": cols[4].text,
+                        "Actual": cols[5].text,
+                        "Expected": cols[6].text,
+                        "Prior": cols[7].text,
+                    }
+                )
         return pd.DataFrame(frame)

--- a/finvizfinance/crypto.py
+++ b/finvizfinance/crypto.py
@@ -5,7 +5,7 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
-from finvizfinance.util import scrap_function, image_scrap_function
+from finvizfinance.util import image_scrap_function, scrap_function
 
 
 class Crypto:

--- a/finvizfinance/earnings.py
+++ b/finvizfinance/earnings.py
@@ -6,14 +6,16 @@
 """
 
 import os
+
 import pandas as pd
+
+from finvizfinance.exceptions import FinvizParseError
 from finvizfinance.screener.financial import Financial
 from finvizfinance.screener.overview import Overview
-from finvizfinance.screener.valuation import Valuation
 from finvizfinance.screener.ownership import Ownership
 from finvizfinance.screener.performance import Performance
 from finvizfinance.screener.technical import Technical
-from finvizfinance.exceptions import FinvizParseError
+from finvizfinance.screener.valuation import Valuation
 
 
 class Earnings:
@@ -44,7 +46,7 @@ class Earnings:
         check_list = ["This Week", "Next Week", "Previous Week", "This Month"]
         if period not in check_list:
             raise ValueError(
-                "Invalid period '{}'. Available period: {}".format(period, check_list)
+                f"Invalid period '{period}'. Available period: {check_list}"
             )
         self.period = period
         ffinancial = Financial()
@@ -77,9 +79,7 @@ class Earnings:
             "technical",
         ]
         if mode not in check_list:
-            raise ValueError(
-                "Invalid mode '{}'. Available mode: {}".format(mode, check_list)
-            )
+            raise ValueError(f"Invalid mode '{mode}'. Available mode: {check_list}")
 
         for earning_day in self.earning_days:
             if mode == "financial":

--- a/finvizfinance/exceptions.py
+++ b/finvizfinance/exceptions.py
@@ -38,9 +38,9 @@ class FinvizParseError(FinvizError, AttributeError, IndexError, KeyError, TypeEr
         if message is None:
             message = (
                 "Failed to parse finviz response: required element "
-                "'{selector}' not found at {url}. "
+                f"'{selector}' not found at {url}. "
                 "Finviz markup may have changed (Drift)."
-            ).format(selector=selector, url=url)
+            )
         super().__init__(message)
 
 
@@ -56,9 +56,9 @@ class FinvizBlockedError(FinvizError, requests.exceptions.HTTPError):
         self.url = url
         if message is None:
             message = (
-                "finviz blocked the request at {url} (Cloudflare challenge / 403). "
+                f"finviz blocked the request at {url} (Cloudflare challenge / 403). "
                 "The source IP is being rate-limited. Slow down your request rate, "
                 "or supply your own session/proxy via "
                 "finvizfinance.util.set_session() or set_proxy()."
-            ).format(url=url)
+            )
         super().__init__(message)

--- a/finvizfinance/forex.py
+++ b/finvizfinance/forex.py
@@ -5,7 +5,7 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
-from finvizfinance.util import scrap_function, image_scrap_function
+from finvizfinance.util import image_scrap_function, scrap_function
 
 
 class Forex:

--- a/finvizfinance/future.py
+++ b/finvizfinance/future.py
@@ -7,9 +7,11 @@
 
 import json
 import re
+
 import pandas as pd
-from finvizfinance.util import web_scrap
+
 from finvizfinance.exceptions import FinvizParseError
+from finvizfinance.util import web_scrap
 
 FUTURES_URL = "https://finviz.com/futures_performance.ashx"
 
@@ -26,9 +28,11 @@ def _extract_rows(soup):
         if match is None:
             continue
         try:
-            data, _ = json.JSONDecoder().raw_decode(html[match.end():].lstrip())
-        except json.JSONDecodeError:
-            raise FinvizParseError(url=FUTURES_URL, selector="futures performance JSON")
+            data, _ = json.JSONDecoder().raw_decode(html[match.end() :].lstrip())
+        except json.JSONDecodeError as err:
+            raise FinvizParseError(
+                url=FUTURES_URL, selector="futures performance JSON"
+            ) from err
         return data
     raise FinvizParseError(url=FUTURES_URL, selector="futures performance JSON")
 
@@ -46,7 +50,7 @@ class Future:
         if timeframe in timeframe_dict:
             params["v"] = timeframe_dict[timeframe]
         elif timeframe != "D":
-            raise ValueError("Invalid timeframe '{}'".format(timeframe))
+            raise ValueError(f"Invalid timeframe '{timeframe}'")
 
         soup = web_scrap(FUTURES_URL, params)
         return pd.DataFrame(_extract_rows(soup))

--- a/finvizfinance/group/__init__.py
+++ b/finvizfinance/group/__init__.py
@@ -2,5 +2,15 @@ from finvizfinance.group.custom import Custom
 from finvizfinance.group.overview import Overview
 from finvizfinance.group.performance import Performance
 from finvizfinance.group.spectrum import Spectrum
-from finvizfinance.group.valuation import Valuation
 from finvizfinance.group.util import get_group, get_orders
+from finvizfinance.group.valuation import Valuation
+
+__all__ = [
+    "Custom",
+    "Overview",
+    "Performance",
+    "Spectrum",
+    "Valuation",
+    "get_group",
+    "get_orders",
+]

--- a/finvizfinance/group/base.py
+++ b/finvizfinance/group/base.py
@@ -6,8 +6,9 @@
 """
 
 import pandas as pd
-from finvizfinance.util import web_scrap, number_convert, require
+
 from finvizfinance.constants import group_dict, group_order_dict
+from finvizfinance.util import number_convert, require, web_scrap
 
 
 class Base:
@@ -41,16 +42,12 @@ class Base:
         if group not in group_dict:
             group_keys = list(group_dict.keys())
             raise ValueError(
-                "Invalid group parameter '{}'. Possible parameter input: {}".format(
-                    group, group_keys
-                )
+                f"Invalid group parameter '{group}'. Possible parameter input: {group_keys}"
             )
         if order not in group_order_dict:
             order_keys = list(group_order_dict.keys())
             raise ValueError(
-                "Invalid order parameter '{}'. Possible parameter input: {}".format(
-                    order, order_keys
-                )
+                f"Invalid order parameter '{order}'. Possible parameter input: {order_keys}"
             )
 
         self.request_params = {

--- a/finvizfinance/group/custom.py
+++ b/finvizfinance/group/custom.py
@@ -21,9 +21,7 @@ class Custom(Base):
         columns = [str(i) for i in columns]
         self.request_params["c"] = ",".join(columns)
 
-    def screener_view(
-        self, group="Sector", order="Name", columns=[0, 1, 2, 3, 10, 22, 24, 25, 26]
-    ):
+    def screener_view(self, group="Sector", order="Name", columns=None):
         """Get screener table.
 
         Args:
@@ -33,4 +31,6 @@ class Custom(Base):
         Returns:
             df(pandas.DataFrame): group information table.
         """
+        if columns is None:
+            columns = [0, 1, 2, 3, 10, 22, 24, 25, 26]
         return Base.screener_view(self, group, order, columns)

--- a/finvizfinance/group/spectrum.py
+++ b/finvizfinance/group/spectrum.py
@@ -5,9 +5,9 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
-from finvizfinance.group.base import Base
-from finvizfinance.util import web_scrap, image_scrap
 from finvizfinance.constants import group_dict, group_order_dict
+from finvizfinance.group.base import Base
+from finvizfinance.util import image_scrap, web_scrap
 
 
 class Spectrum(Base):
@@ -27,16 +27,12 @@ class Spectrum(Base):
         if group not in group_dict:
             group_keys = list(group_dict.keys())
             raise ValueError(
-                "Invalid group parameter '{}'. Possible parameter input: {}".format(
-                    group, group_keys
-                )
+                f"Invalid group parameter '{group}'. Possible parameter input: {group_keys}"
             )
         if order not in group_order_dict.order_dict:
             order_keys = list(group_order_dict.keys())
             raise ValueError(
-                "Invalid order parameter '{}'. Possible parameter input: {}".format(
-                    order, order_keys
-                )
+                f"Invalid order parameter '{order}'. Possible parameter input: {order_keys}"
             )
 
         self.request_params = self.request_params.update(group_dict[group])

--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -6,7 +6,8 @@
 """
 
 import pandas as pd
-from finvizfinance.util import web_scrap, number_convert, find_table_by_headers
+
+from finvizfinance.util import find_table_by_headers, number_convert, web_scrap
 
 INSIDER_URL = "https://finviz.com/insidertrading"
 

--- a/finvizfinance/news.py
+++ b/finvizfinance/news.py
@@ -6,8 +6,9 @@
 """
 
 import pandas as pd
-from finvizfinance.util import web_scrap, require
+
 from finvizfinance.exceptions import FinvizParseError
+from finvizfinance.util import require, web_scrap
 
 NEWS_URL = "https://finviz.com/news.ashx"
 
@@ -40,9 +41,7 @@ class News:
         news_collection = tr_list[1]
         tables = news_collection.find_all("table")
         if len(tables) < 2:
-            raise FinvizParseError(
-                url=NEWS_URL, selector="#news news/blogs tables"
-            )
+            raise FinvizParseError(url=NEWS_URL, selector="#news news/blogs tables")
 
         news_df = self._get_news_helper(tables[0])
         blog_df = self._get_news_helper(tables[1])

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -5,20 +5,22 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
-from datetime import datetime, date
 import re
+from datetime import date, datetime
+
 import pandas as pd
+
+from finvizfinance.exceptions import FinvizParseError
 from finvizfinance.util import (
-    web_scrap,
-    web_scrap_json,
+    format_datetime,
     image_scrap,
     number_convert,
-    format_datetime,
-    require,
     optional,
+    require,
     warn_missing,
+    web_scrap,
+    web_scrap_json,
 )
-from finvizfinance.exceptions import FinvizParseError
 
 QUOTE_URL = "https://finviz.com/quote.ashx?t={ticker}"
 NUM_COL = [
@@ -45,7 +47,7 @@ class Quote:
         Returns:
             price(float): price of the ticker
         """
-        soup = web_scrap("https://finviz.com/request_quote.ashx?t={}".format(ticker))
+        soup = web_scrap(f"https://finviz.com/request_quote.ashx?t={ticker}")
         return soup.text
 
 
@@ -97,9 +99,9 @@ class finvizfinance:
             charturl(str): url for the chart
         """
         if timeframe not in ["daily", "weekly", "monthly"]:
-            raise ValueError("Invalid timeframe '{}'".format(timeframe))
+            raise ValueError(f"Invalid timeframe '{timeframe}'")
         if charttype not in ["candle", "line", "advanced"]:
-            raise ValueError("Invalid chart type '{}'".format(charttype))
+            raise ValueError(f"Invalid chart type '{charttype}'")
         url_type = "c"
         url_ta = "0"
         if charttype == "line":
@@ -114,9 +116,7 @@ class finvizfinance:
             url_timeframe = "w"
         elif timeframe == "monthly":
             url_timeframe = "m"
-        chart_url = "https://finviz.com/chart.ashx?t={ticker}&ty={type}&ta={ta}&p={timeframe}".format(
-            ticker=self.ticker, type=url_type, ta=url_ta, timeframe=url_timeframe
-        )
+        chart_url = f"https://finviz.com/chart.ashx?t={self.ticker}&ty={url_type}&ta={url_ta}&p={url_timeframe}"
         if not urlonly:
             image_scrap(chart_url, self.ticker, out_dir)
         return chart_url
@@ -129,7 +129,7 @@ class finvizfinance:
         finally returns ``None`` with a warning for anything genuinely absent.
         """
         keys = ["Sector", "Industry", "Country", "Exchange"]
-        result = {k: None for k in keys}
+        result = dict.fromkeys(keys)
 
         quote_links = self.soup.find("div", class_="quote-links")
         if quote_links is not None:
@@ -155,9 +155,7 @@ class finvizfinance:
         # Missing-field semantics: warn and keep None for anything still absent.
         for key in keys:
             if result[key] is None:
-                warn_missing(
-                    self.quote_url, "quote classification link ({})".format(key)
-                )
+                warn_missing(self.quote_url, f"quote classification link ({key})")
         return result
 
     def ticker_fundament(self, raw=True, output_format="dict"):
@@ -228,7 +226,7 @@ class finvizfinance:
                         fundament_info[header] = False
                 else:
                     # Handle EPS Next Y keys with two different values
-                    if header == "EPS next Y" and header in fundament_info.keys():
+                    if header == "EPS next Y" and header in fundament_info:
                         header += " Percentage"
                     if raw:
                         fundament_info[header] = value
@@ -288,7 +286,7 @@ class finvizfinance:
         link = self.soup.find("a", string=label)
         if not link:
             link = self.soup.find(
-                "a", string=re.compile(r"^\s*{}\s*$".format(label), re.IGNORECASE)
+                "a", string=re.compile(rf"^\s*{label}\s*$", re.IGNORECASE)
             )
         if not link:
             warn_missing(self.quote_url, selector)
@@ -526,8 +524,8 @@ class Statements:
             df(pandas.DataFrame): statements table. The reporting currency (e.g.
                 "USD") is stored in ``df.attrs["currency"]``.
         """
-        url = "https://finviz.com/api/statement.ashx?t={ticker}&s={statement}{timeframe}".format(
-            ticker=ticker, statement=statement, timeframe=timeframe
+        url = (
+            f"https://finviz.com/api/statement.ashx?t={ticker}&s={statement}{timeframe}"
         )
         response = web_scrap_json(url)
         if "data" not in response:

--- a/finvizfinance/screener/__init__.py
+++ b/finvizfinance/screener/__init__.py
@@ -5,11 +5,27 @@ from finvizfinance.screener.ownership import Ownership
 from finvizfinance.screener.performance import Performance
 from finvizfinance.screener.technical import Technical
 from finvizfinance.screener.ticker import Ticker
-from finvizfinance.screener.valuation import Valuation
 from finvizfinance.screener.util import (
-    get_signal,
-    get_filters,
-    get_filter_options,
-    get_orders,
     get_custom_screener_columns,
+    get_filter_options,
+    get_filters,
+    get_orders,
+    get_signal,
 )
+from finvizfinance.screener.valuation import Valuation
+
+__all__ = [
+    "Custom",
+    "Financial",
+    "Overview",
+    "Ownership",
+    "Performance",
+    "Technical",
+    "Ticker",
+    "Valuation",
+    "get_custom_screener_columns",
+    "get_filter_options",
+    "get_filters",
+    "get_orders",
+    "get_signal",
+]

--- a/finvizfinance/screener/base.py
+++ b/finvizfinance/screener/base.py
@@ -7,16 +7,18 @@
 """
 
 import warnings
-import pandas as pd
 from time import sleep
+
+import pandas as pd
+
+from finvizfinance.constants import NUMBER_COL, filter_dict, order_dict, signal_dict
 from finvizfinance.quote import finvizfinance
 from finvizfinance.util import (
-    web_scrap,
     number_convert,
     progress_bar,
     require,
+    web_scrap,
 )
-from finvizfinance.constants import NUMBER_COL, signal_dict, filter_dict, order_dict
 
 
 class Base:
@@ -44,7 +46,7 @@ class Base:
         if signal not in signal_dict:
             signal_keys = list(signal_dict.keys())
             raise ValueError(
-                "Invalid signal '{}'. Possible signal: {}".format(signal, signal_keys)
+                f"Invalid signal '{signal}'. Possible signal: {signal_keys}"
             )
         self.request_params["s"] = signal_dict[signal]
 
@@ -62,19 +64,17 @@ class Base:
             if key not in filter_dict:
                 filter_keys = list(filter_dict.keys())
                 raise ValueError(
-                    "Invalid filter '{}'. Possible filter: {}".format(key, filter_keys)
+                    f"Invalid filter '{key}'. Possible filter: {filter_keys}"
                 )
             if value not in filter_dict[key]["option"]:
                 filter_options = list(filter_dict[key]["option"].keys())
                 raise ValueError(
-                    "Invalid filter option '{}'. Possible filter options: {}".format(
-                        value, filter_options
-                    )
+                    f"Invalid filter option '{value}'. Possible filter options: {filter_options}"
                 )
             prefix = filter_dict[key]["prefix"]
             urlcode = filter_dict[key]["option"][value]
             if urlcode != "":
-                filters.append("{}_{}".format(prefix, urlcode))
+                filters.append(f"{prefix}_{urlcode}")
         if len(filters) != 0:
             self.request_params["f"] = ",".join(filters)
 
@@ -88,7 +88,7 @@ class Base:
             return
         self.request_params["t"] = ticker
 
-    def set_filter(self, signal="", filters_dict={}, ticker=""):
+    def set_filter(self, signal="", filters_dict=None, ticker=""):
         """Update the settings.
 
         Args:
@@ -96,6 +96,8 @@ class Base:
             filters_dict(dict): dictionary of filters
             ticker(str): ticker string
         """
+        if filters_dict is None:
+            filters_dict = {}
         self._set_signal(signal)
         self._set_ticker(ticker)
         self._set_filters(filters_dict)
@@ -203,9 +205,7 @@ class Base:
         """
         if order not in order_dict:
             order_keys = list(order_dict.keys())
-            raise ValueError(
-                "Invalid order '{}'. Possible order: {}".format(order, order_keys)
-            )
+            raise ValueError(f"Invalid order '{order}'. Possible order: {order_keys}")
         self.request_params["o"] = ("" if ascend else "-") + order_dict[order]
 
         if select_page:
@@ -224,7 +224,9 @@ class Base:
         if select_page:
             if select_page > page:
                 return None
-            warnings.warn("Limit parameter is ignored when page is selected.")
+            warnings.warn(
+                "Limit parameter is ignored when page is selected.", stacklevel=2
+            )
             return df
 
         for i in range(1, page):
@@ -254,7 +256,7 @@ class Base:
         check_list = ["Sector", "Industry", "Country"]
         error_list = [i for i in compare_list if i not in check_list]
         if len(error_list) != 0:
-            raise ValueError("Please check: {}".format(error_list))
+            raise ValueError(f"Please check: {error_list}")
 
         stock = finvizfinance(ticker)
         stock_fundament = stock.ticker_fundament()

--- a/finvizfinance/screener/custom.py
+++ b/finvizfinance/screener/custom.py
@@ -31,7 +31,7 @@ class Custom(Base):
         select_page=None,
         verbose=1,
         ascend=True,
-        columns=[0, 1, 2, 3, 4, 5, 6, 7, 65, 66, 67],
+        columns=None,
         sleep_sec=1,
     ):
         """Get screener table.
@@ -47,6 +47,8 @@ class Custom(Base):
         Returns:
             df(pandas.DataFrame): screener information table
         """
+        if columns is None:
+            columns = [0, 1, 2, 3, 4, 5, 6, 7, 65, 66, 67]
         return Base.screener_view(
             self, order, limit, select_page, verbose, ascend, columns, sleep_sec
         )

--- a/finvizfinance/screener/ticker.py
+++ b/finvizfinance/screener/ticker.py
@@ -6,14 +6,14 @@
 """
 
 from time import sleep
+
+from finvizfinance.constants import order_dict
+from finvizfinance.screener.base import Base
 from finvizfinance.util import (
-    web_scrap,
     progress_bar,
     require,
+    web_scrap,
 )
-from finvizfinance.constants import order_dict
-
-from finvizfinance.screener.base import Base
 
 
 class Ticker(Base):
@@ -51,9 +51,7 @@ class Ticker(Base):
         """
         if order not in order_dict:
             order_keys = list(order_dict.keys())
-            raise ValueError(
-                "Invalid order '{}'. Possible order: {}".format(order, order_keys)
-            )
+            raise ValueError(f"Invalid order '{order}'. Possible order: {order_keys}")
         self.request_params["o"] = ("" if ascend else "-") + order_dict[order]
         soup = web_scrap(self.url, self.request_params)
         page = self._get_page(soup)
@@ -61,9 +59,8 @@ class Ticker(Base):
             print("No ticker found.")
             return None
 
-        if limit != -1:
-            if page > (limit - 1) // 1000 + 1:
-                page = (limit - 1) // 1000 + 1
+        if limit != -1 and page > (limit - 1) // 1000 + 1:
+            page = (limit - 1) // 1000 + 1
 
         if verbose == 1:
             progress_bar(1, page)

--- a/finvizfinance/screener/util.py
+++ b/finvizfinance/screener/util.py
@@ -1,8 +1,8 @@
 from finvizfinance.constants import (
-    signal_dict,
+    CUSTOM_SCREENER_COLUMNS,
     filter_dict,
     order_dict,
-    CUSTOM_SCREENER_COLUMNS,
+    signal_dict,
 )
 
 
@@ -36,9 +36,7 @@ def get_filter_options(screen_filter):
     if screen_filter not in filter_dict:
         filter_keys = list(filter_dict.keys())
         raise ValueError(
-            "Invalid filter '{}'. Possible filter: {}".format(
-                screen_filter, filter_keys
-            )
+            f"Invalid filter '{screen_filter}'. Possible filter: {filter_keys}"
         )
     return list(filter_dict[screen_filter]["option"])
 

--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -5,19 +5,20 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+import json
 import sys
 import time
-import json
 import warnings
-import requests
+from datetime import date, datetime
+
 import pandas as pd
+import requests
 from bs4 import BeautifulSoup
-from datetime import datetime, date
 
 from finvizfinance.exceptions import (  # noqa: F401  (re-exported for convenience)
+    FinvizBlockedError,
     FinvizError,
     FinvizParseError,
-    FinvizBlockedError,
 )
 
 # A current browser User-Agent. A trivially-outdated client string (the old
@@ -89,11 +90,7 @@ def _is_wall(response):
     if response.headers.get("cf-mitigated") == "challenge":
         return True
     body = getattr(response, "text", "") or ""
-    return (
-        "Just a moment" in body
-        or "cf-chl" in body
-        or "challenge-platform" in body
-    )
+    return "Just a moment" in body or "cf-chl" in body or "challenge-platform" in body
 
 
 def _retry_after(response, attempt):
@@ -101,7 +98,7 @@ def _retry_after(response, attempt):
     header = response.headers.get("Retry-After") if response is not None else None
     if header and header.replace(".", "", 1).isdigit():
         return min(float(header), BACKOFF_CAP)
-    return min(BACKOFF_BASE * (2 ** attempt), BACKOFF_CAP)
+    return min(BACKOFF_BASE * (2**attempt), BACKOFF_CAP)
 
 
 def _request(url, params=None, stream=False):
@@ -132,14 +129,12 @@ def _request(url, params=None, stream=False):
                 continue
             raise FinvizBlockedError(
                 message=(
-                    "finviz request to {url} timed out after {n} attempts "
-                    "({err}). The source IP may be rate-limited; slow down or "
-                    "supply a proxy/session via set_session()/set_proxy().".format(
-                        url=url, n=MAX_RETRIES + 1, err=err
-                    )
+                    f"finviz request to {url} timed out after {MAX_RETRIES + 1} attempts "
+                    f"({err}). The source IP may be rate-limited; slow down or "
+                    "supply a proxy/session via set_session()/set_proxy()."
                 ),
                 url=url,
-            )
+            ) from err
 
         if _is_wall(response):
             if attempt < MAX_RETRIES:
@@ -155,8 +150,8 @@ def _request(url, params=None, stream=False):
             response.raise_for_status()
         except requests.exceptions.HTTPError as err:
             raise requests.exceptions.HTTPError(
-                "HTTP error for URL {}: {}".format(url, err)
-            )
+                f"HTTP error for URL {url}: {err}"
+            ) from err
         return response
 
     # Unreachable: the loop either returns or raises. Guard anyway.
@@ -210,14 +205,14 @@ def image_scrap(url, ticker, out_dir):
     response = _request(url, stream=True)
     if len(out_dir) != 0:
         out_dir += "/"
-    with open("{}{}.jpg".format(out_dir, ticker), "wb") as f:
+    with open(f"{out_dir}{ticker}.jpg", "wb") as f:
         f.write(response.content)
 
 
 def warn_missing(url, selector):
     """Emit the standard Missing-field warning for an absent optional datum."""
     warnings.warn(
-        "Optional element '{}' not found at {}".format(selector, url),
+        f"Optional element '{selector}' not found at {url}",
         stacklevel=2,
     )
 
@@ -286,12 +281,14 @@ def scrap_function(url):
         df(pandas.DataFrame): performance table
     """
     soup = web_scrap(url)
-    table = require(soup.find("table", class_="groups_table"), url, "table.groups_table")
+    table = require(
+        soup.find("table", class_="groups_table"), url, "table.groups_table"
+    )
     rows = table.find_all("tr")
     table_header = [i.text.strip() for i in rows[0].find_all("th")][1:]
     frame = []
     rows = rows[1:]
-    num_col_index = [i for i in range(2, len(table_header))]
+    num_col_index = list(range(2, len(table_header)))
     for row in rows:
         cols = row.find_all("td")[1:]
         info_dict = {}
@@ -397,5 +394,5 @@ def progress_bar(page, total):
     bar_len = 30
     filled_len = int(round(bar_len * page / float(total)))
     bar = "#" * filled_len + "-" * (bar_len - filled_len)
-    sys.stdout.write("[Info] loading page [{}] {}/{} \r".format(bar, page, total))
+    sys.stdout.write(f"[Info] loading page [{bar}] {page}/{total} \r")
     sys.stdout.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dev = [
     "coverage>=7.5",
     "coveralls>=4.0",
     "pyyaml>=6.0",
+    "ruff>=0.6",
+    "pre-commit>=3.5",
 ]
 
 [project.urls]
@@ -67,3 +69,16 @@ include = [
     "/README.md",
     "/LICENSE",
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+# Ruff also reformats fenced Python in Markdown and cells in notebooks; keep the
+# sweep scoped to Python sources and leave docs/examples alone.
+extend-exclude = ["*.md", "*.ipynb"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "C4"]
+# Line length is enforced by the formatter; E501 only fires on long strings/data
+# (finviz filter tables, URLs) it cannot split, so it is noise here.
+ignore = ["E501"]

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -93,21 +93,19 @@ def main():
         try:
             check()
             ok.append(name)
-            print("OK      {}".format(name))
+            print(f"OK      {name}")
         except FinvizBlockedError:
             blocked.append(name)
-            print("BLOCKED {} (Wall — expected from a datacenter IP)".format(name))
+            print(f"BLOCKED {name} (Wall — expected from a datacenter IP)")
         except FinvizParseError as err:
             drift.append(name)
-            print("DRIFT   {} -> {}".format(name, err))
+            print(f"DRIFT   {name} -> {err}")
         except Exception as err:  # noqa: BLE001
             errors.append(name)
-            print("ERROR   {} -> {}: {}".format(name, type(err).__name__, err))
+            print(f"ERROR   {name} -> {type(err).__name__}: {err}")
 
     print(
-        "\nSummary: {} ok, {} blocked (expected), {} DRIFT, {} error".format(
-            len(ok), len(blocked), len(drift), len(errors)
-        )
+        f"\nSummary: {len(ok)} ok, {len(blocked)} blocked (expected), {len(drift)} DRIFT, {len(errors)} error"
     )
     if drift:
         print("Drift detected (finviz markup changed): {}".format(", ".join(drift)))

--- a/scripts/refresh_fixtures.py
+++ b/scripts/refresh_fixtures.py
@@ -52,16 +52,16 @@ def main():
             response = util.fetch(url)
             with open(path, "w", encoding="utf-8") as f:
                 f.write(response.text)
-            print("saved   {:<28} <- {}".format(name, url))
+            print(f"saved   {name:<28} <- {url}")
         except FinvizBlockedError:
             blocked += 1
-            print("BLOCKED {:<28} (Wall — try an allowed IP / proxy)".format(name))
+            print(f"BLOCKED {name:<28} (Wall — try an allowed IP / proxy)")
         except Exception as err:  # noqa: BLE001 - report and continue refreshing
-            print("ERROR   {:<28} {}: {}".format(name, type(err).__name__, err))
+            print(f"ERROR   {name:<28} {type(err).__name__}: {err}")
     if blocked:
         print(
-            "\n{} endpoint(s) Walled. Supply a proxy/session and re-run to "
-            "refresh those.".format(blocked)
+            f"\n{blocked} endpoint(s) Walled. Supply a proxy/session and re-run to "
+            "refresh those."
         )
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,7 +44,7 @@ class FakeResponse:
     def raise_for_status(self):
         if self.status_code >= 400:
             raise requests.exceptions.HTTPError(
-                "{} Client Error".format(self.status_code), response=self
+                f"{self.status_code} Client Error", response=self
             )
 
 

--- a/test/test_calendar.py
+++ b/test/test_calendar.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the calendar scraper (see test_quote for the pattern)."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
 from finvizfinance.calendar import Calendar
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 
 
 def test_calendar_real():
@@ -20,11 +19,17 @@ def test_calendar_real():
 def test_calendar_current_client_rendered_format():
     use_session(html_response("calendar_current.html"))
     df = Calendar().calendar()
-    assert df.to_dict("records") == [{
-        "Datetime": "Mon Aug 26, 08:30 AM", "Release": "GDP Growth Rate",
-        "Impact": "3", "For": "Q2", "Actual": "3.0%",
-        "Expected": "2.8%", "Prior": "2.5%",
-    }]
+    assert df.to_dict("records") == [
+        {
+            "Datetime": "Mon Aug 26, 08:30 AM",
+            "Release": "GDP Growth Rate",
+            "Impact": "3",
+            "For": "Q2",
+            "Actual": "3.0%",
+            "Expected": "2.8%",
+            "Prior": "2.5%",
+        }
+    ]
 
 
 def test_calendar_current_unknown_keys_raise_parse_error():

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the crypto scraper (see test_quote for the pattern)."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
 from finvizfinance.crypto import Crypto
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 
 
 def test_crypto_performance_real():

--- a/test/test_earnings.py
+++ b/test/test_earnings.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the earnings exporter (composes the screeners)."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
 from finvizfinance.earnings import Earnings
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 
 
 def test_earnings_partition_financial():

--- a/test/test_forex.py
+++ b/test/test_forex.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the forex scraper (see test_quote for the pattern)."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 from finvizfinance.forex import Forex
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
 
 
 def test_forex_performance_real():

--- a/test/test_future.py
+++ b/test/test_future.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the future scraper."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 from finvizfinance.future import Future
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
 
 
 def test_future_real():

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the group views (see test_quote for the pattern)."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 from finvizfinance.group.overview import Overview
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
 
 
 def test_group_overview_real():

--- a/test/test_insider.py
+++ b/test/test_insider.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the insider scraper (see test_quote for the pattern)."""
 
 import pytest
+from conftest import FakeResponse, blocked_response, html_response, use_session
 
-from finvizfinance.insider import Insider, INSIDER_URL
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response, FakeResponse
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
+from finvizfinance.insider import INSIDER_URL, Insider
 
 
 def test_insider_real():

--- a/test/test_news.py
+++ b/test/test_news.py
@@ -1,11 +1,10 @@
 """Offline fixture tests for the news scraper (see test_quote for the pattern)."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 from finvizfinance.news import News
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
 
 
 def test_news_real():

--- a/test/test_quote.py
+++ b/test/test_quote.py
@@ -7,11 +7,10 @@ missing optional field.
 """
 
 import pytest
+from conftest import FakeResponse, blocked_response, html_response, use_session
 
-from finvizfinance.quote import finvizfinance, Statements
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response, FakeResponse
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
+from finvizfinance.quote import Statements, finvizfinance
 
 
 def _stock(fixture):
@@ -154,9 +153,7 @@ def test_ticker_inside_trader():
 
 def test_ticker_full_info():
     info = _stock("quote_aapl.html").ticker_full_info()
-    assert set(["fundament", "ratings_outer", "news", "inside trader"]).issubset(
-        info.keys()
-    )
+    assert {"fundament", "ratings_outer", "news", "inside trader"}.issubset(info.keys())
 
 
 def test_ticker_signal_wall_surfaces_not_silently_dropped():
@@ -178,7 +175,9 @@ def test_ticker_charts_invalid_timeframe():
 
 def test_statements_real():
     use_session(
-        FakeResponse(content=b'{"currency": "USD", "data": {"2023": {"Revenue": "100"}}}')
+        FakeResponse(
+            content=b'{"currency": "USD", "data": {"2023": {"Revenue": "100"}}}'
+        )
     )
     df = Statements().get_statements("AAPL")
     assert df is not None

--- a/test/test_screener.py
+++ b/test/test_screener.py
@@ -1,14 +1,13 @@
 """Offline fixture tests for the screener views (see test_quote for the pattern)."""
 
 import pytest
+from conftest import blocked_response, html_response, use_session
 
+from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
+from finvizfinance.screener import get_filter_options, get_filters, get_signal
+from finvizfinance.screener.custom import Custom
 from finvizfinance.screener.overview import Overview
 from finvizfinance.screener.ticker import Ticker
-from finvizfinance.screener.custom import Custom
-from finvizfinance.screener import get_signal, get_filters, get_filter_options
-from finvizfinance.exceptions import FinvizParseError, FinvizBlockedError
-
-from conftest import use_session, html_response, blocked_response
 
 
 def test_screener_overview_real():

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,28 +2,26 @@ import warnings
 
 import pytest
 import requests
+from bs4 import BeautifulSoup
+from conftest import FakeResponse, blocked_response, use_session
 
 from finvizfinance import util
+from finvizfinance.exceptions import (
+    FinvizBlockedError,
+    FinvizError,
+    FinvizParseError,
+)
 from finvizfinance.util import (
-    web_scrap,
-    web_scrap_json,
-    set_proxy,
-    require,
-    optional,
-    warn_missing,
     find_table_by_headers,
     number_convert,
     number_covert,
+    optional,
+    require,
+    set_proxy,
+    warn_missing,
+    web_scrap,
+    web_scrap_json,
 )
-from finvizfinance.exceptions import (
-    FinvizError,
-    FinvizParseError,
-    FinvizBlockedError,
-)
-from bs4 import BeautifulSoup
-
-from conftest import use_session, html_response, blocked_response, FakeResponse
-
 
 # --- transport: injectable session seam -------------------------------------
 


### PR DESCRIPTION
## Summary

Adopt **ruff** (linter + formatter) with **pre-commit**, and run the initial cleanup sweep. This is PR 2 of the staged modernization effort. **No runtime behavior change** — the offline test suite (93 tests) still passes.

Depends on #168 (needs `pyproject.toml`); branch off `develop` after that merged.

## Tooling

- `[tool.ruff]` in `pyproject.toml`: `line-length = 88`, `target-version = "py310"`, `select = [E, F, I, UP, B, SIM, C4]`.
- `ignore = ["E501"]` — the formatter already governs line length; E501 only fires on long strings/data (finviz filter tables, URLs) it can't split.
- `extend-exclude = ["*.md", "*.ipynb"]` — ruff also reformats fenced Python in Markdown and notebook cells; scope this to Python sources so docs/examples aren't rewritten.
- New `.pre-commit-config.yaml` with `ruff-check --fix` + `ruff-format` (pinned to v0.16.4). `ruff`, `pre-commit` added to the `dev` extra.

## Sweep (all auto/mechanical, test-verified)

- `UP` → `str.format()`/`%` converted to f-strings; `I` → imports sorted.
- `B904` → re-raised exceptions now chain with `from err` (`util`, `calendar`, `future`).
- `B006` → mutable default args replaced with `None` + guard (`screener/base.set_filter`, `screener/custom`, `group/custom`).
- `B028` → explicit `stacklevel` on `warnings.warn`.
- `SIM`/`C4` → collapse nested `if`, drop a redundant `.keys()`, use set/list literals.
- `F401` → public re-exports declared via `__all__` in `group/__init__.py` and `screener/__init__.py` (keeps the re-exports, documents the public surface).

## Docs

- README code-style badge: black → ruff.

## Validation

- `ruff check .` → All checks passed.
- `ruff format --check .` → 46 files already formatted.
- `pre-commit run --all-files` → ruff-check + ruff-format both pass.
- `pytest test` → 93 passed.
- `python -m build` + `twine check` → both artifacts PASS.

## Follow-ups

- PR3 wires the ruff (and later mypy) gates into CI when it moves to GitHub Actions; a `ruff format`/`ruff check` gate is not added to the current CircleCI here.
