### PR TITLE
build(deps): raise requests floor to >=2.32.0 for CVE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "pandas>=1.5",
-    "requests>=2.25",
+    "requests>=2.32.0",
     "beautifulsoup4>=4.9",
     "lxml>=4.6",
     "xlsxwriter>=3.0",


### PR DESCRIPTION
## Description

Raises the `requests` dependency floor from `>=2.25` to `>=2.32.0` in `pyproject.toml`. The previous floor permitted `requests` versions affected by two published advisories:

- **CVE-2023-32681** — the `Proxy-Authorization` header was leaked to the destination server on a cross-host redirect (fixed in requests 2.31.0).
- **CVE-2024-35195** — a `Session` created with `verify=False` kept skipping certificate verification on all subsequent requests (fixed in requests 2.32.0).

Because this is a floor (not a pin), fresh installs already resolve to 2.32.x; the bump just prevents a downstream environment from pinning an affected version. `requests` 2.32.0 supports Python 3.8+, so this is non-breaking for every supported interpreter (`requires-python >=3.10`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What you did

- Bumped `requests>=2.25` → `requests>=2.32.0` in `pyproject.toml`.
- Verified `pyproject.toml` still parses and the full offline test suite passes (93 passed).
