### PR TITLE
fix: revive group.Spectrum and guard screener ticker parsing

### DIFF
--- a/finvizfinance/group/spectrum.py
+++ b/finvizfinance/group/spectrum.py
@@ -5,9 +5,11 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from urllib.parse import urljoin
+
 from finvizfinance.constants import group_dict, group_order_dict
 from finvizfinance.group.base import Base
-from finvizfinance.util import image_scrap, web_scrap
+from finvizfinance.util import image_scrap, require, web_scrap
 
 
 class Spectrum(Base):
@@ -29,15 +31,22 @@ class Spectrum(Base):
             raise ValueError(
                 f"Invalid group parameter '{group}'. Possible parameter input: {group_keys}"
             )
-        if order not in group_order_dict.order_dict:
+        if order not in group_order_dict:
             order_keys = list(group_order_dict.keys())
             raise ValueError(
                 f"Invalid order parameter '{order}'. Possible parameter input: {order_keys}"
             )
 
-        self.request_params = self.request_params.update(group_dict[group])
+        self.request_params.update(group_dict[group])
         self.request_params["o"] = group_order_dict[order]
 
         soup = web_scrap(self.url, self.request_params)
-        url = "https://finviz.com/" + soup.find_all("img")[5]["src"]
+        image = None
+        for candidate in soup.find_all("img"):
+            src = candidate.get("src", "")
+            if "spectrum" in src.lower():
+                image = candidate
+                break
+        image = require(image, self.url, "img[src*=spectrum]")
+        url = urljoin("https://finviz.com/", image["src"])
         image_scrap(url, group, "")

--- a/finvizfinance/screener/ticker.py
+++ b/finvizfinance/screener/ticker.py
@@ -32,7 +32,11 @@ class Ticker(Base):
         page_tickers = td.find_all("span")
         if i == page - 1:
             page_tickers = page_tickers[: ((limit - 1) % 1000 + 1)]
-        tickers = tickers + [i.text.split("\xa0")[1] for i in page_tickers]
+        for span in page_tickers:
+            parts = span.text.split("\xa0")
+            # Cells normally read "<rank>\xa0<TICKER>"; fall back to the whole
+            # text when the NBSP-separated rank is absent (avoids IndexError).
+            tickers.append(parts[1] if len(parts) > 1 else parts[0])
         return tickers
 
     def screener_view(

--- a/test/fixtures/group_spectrum.html
+++ b/test/fixtures/group_spectrum.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><title>Sector Spectrum - finviz.com</title></head>
+<body>
+  <a href="/"><img src="gfx/logo.png" alt="finviz"></a>
+  <img src="gfx/banner.png" alt="promo">
+  <img src="spectrum.ashx?ft=4&amp;t=sector&amp;o=name" alt="Sector spectrum">
+  <img src="gfx/footer.png" alt="footer">
+</body>
+</html>

--- a/test/fixtures/group_spectrum_missing_image.html
+++ b/test/fixtures/group_spectrum_missing_image.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Sector Spectrum - finviz.com</title></head>
+<body>
+  <a href="/"><img src="gfx/logo.png" alt="finviz"></a>
+  <img src="gfx/banner.png" alt="promo">
+</body>
+</html>

--- a/test/fixtures/screener_ticker_no_nbsp.html
+++ b/test/fixtures/screener_ticker_no_nbsp.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><title>Screener Ticker View</title></head>
+<body>
+<select id="pageSelect"><option value="1">Page 1/1</option></select>
+<table>
+  <tr><td class="screener-tickers">
+    <span>1&nbsp;AAPL</span>
+    <span>MSFT</span>
+  </td></tr>
+</table>
+</body>
+</html>

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,10 +1,11 @@
 """Offline fixture tests for the group views (see test_quote for the pattern)."""
 
 import pytest
-from conftest import blocked_response, html_response, use_session
+from conftest import FakeResponse, blocked_response, html_response, use_session
 
 from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 from finvizfinance.group.overview import Overview
+from finvizfinance.group.spectrum import Spectrum
 
 
 def test_group_overview_real():
@@ -28,3 +29,51 @@ def test_group_wall_raises_blocked_error():
 def test_group_invalid_group():
     with pytest.raises(ValueError):
         Overview().screener_view(group="Dummy")
+
+
+def test_group_spectrum_downloads_image(tmp_path, monkeypatch):
+    # End-to-end revival check (#advertised-dead-class): before the fix every
+    # call died at the order check (``group_order_dict.order_dict``), then at
+    # ``request_params.update()`` returning None, then at a positional
+    # ``find_all("img")[5]``. Now it fetches the page and downloads the image.
+    monkeypatch.chdir(tmp_path)
+    fake = use_session(
+        [
+            html_response("group_spectrum.html"),
+            FakeResponse(content=b"\xff\xd8\xff\xe0JPEGBYTES", status_code=200),
+        ]
+    )
+    Spectrum().screener_view(group="Sector", order="Name")
+    out = tmp_path / "Sector.jpg"
+    assert out.exists()
+    assert out.read_bytes() == b"\xff\xd8\xff\xe0JPEGBYTES"
+    # Two fetches: the spectrum page, then the spectrum image itself...
+    assert len(fake.calls) == 2
+    # ...and the image is matched by a stable src pattern, not a fixed index
+    # (the fixture holds fewer than 6 <img> and the spectrum is not the 6th).
+    assert "spectrum" in fake.calls[1]["url"].lower()
+
+
+def test_group_spectrum_invalid_group():
+    with pytest.raises(ValueError):
+        Spectrum().screener_view(group="Dummy")
+
+
+def test_group_spectrum_invalid_order():
+    # The order guard used to read ``group_order_dict.order_dict`` — a plain
+    # dict has no such attribute, so *every* call raised AttributeError before
+    # it could validate. It must reject a bad order with ValueError now.
+    with pytest.raises(ValueError):
+        Spectrum().screener_view(order="Dummy")
+
+
+def test_group_spectrum_missing_image_raises_parse_error():
+    use_session(html_response("group_spectrum_missing_image.html"))
+    with pytest.raises(FinvizParseError):
+        Spectrum().screener_view(group="Sector", order="Name")
+
+
+def test_group_spectrum_wall_raises_blocked_error():
+    use_session(blocked_response())
+    with pytest.raises(FinvizBlockedError):
+        Spectrum().screener_view(group="Sector", order="Name")

--- a/test/test_screener.py
+++ b/test/test_screener.py
@@ -94,6 +94,15 @@ def test_screener_ticker_wall_raises_blocked_error():
         Ticker().screener_view(verbose=0)
 
 
+def test_screener_ticker_missing_nbsp_no_indexerror():
+    # Regression: a ticker cell span without the "<rank>\xa0<TICKER>" NBSP
+    # layout made ``text.split("\xa0")[1]`` raise IndexError. The parser must
+    # fall back to the span's whole text instead of crashing.
+    use_session(html_response("screener_ticker_no_nbsp.html"))
+    tickers = Ticker().screener_view(verbose=0)
+    assert tickers == ["AAPL", "MSFT"]
+
+
 def test_screener_get_settings():
     assert isinstance(get_signal(), list)
     assert isinstance(get_filters(), list)


### PR DESCRIPTION
Correctness-first bug fix: `group.Spectrum` was dead on arrival (it crashed on the first call) and `screener.ticker` could `IndexError`. No public API change.

## What was broken
`group.Spectrum.screener_view()` raised on the *first* call at three sites, and `screener.ticker` could `IndexError`:

1. `spectrum.py` order check read `group_order_dict.order_dict` — `group_order_dict` is a plain `dict` (`constants.py:2379`), so **every** call raised `AttributeError` before validating.
2. `spectrum.py` did `self.request_params = self.request_params.update(...)` — `dict.update()` returns `None`, nulling the params; the next `request_params["o"] = ...` then `TypeError`d.
3. `spectrum.py` grabbed the image positionally: `find_all("img")[5]["src"]` — `IndexError` when fewer than 6 `<img>`.
4. `screener/ticker.py` did `i.text.split("\xa0")[1]` — `IndexError` when the `<rank>\xa0<TICKER>` NBSP layout is absent.

## Fix
- **spectrum**: validate `order` against `group_order_dict` directly; `update()` params in place; match the spectrum `<img>` by a stable "spectrum" src pattern via `require()` (raises the typed `FinvizParseError` on drift) instead of a fixed index; build the URL with `urljoin`.
- **ticker**: fall back to the span's whole text when `\xa0` is absent.

## Tests (offline seam only)
- New committed fixtures: `group_spectrum.html`, `group_spectrum_missing_image.html`, `screener_ticker_no_nbsp.html` (raw HTML, so a future finviz drift shows up as a readable diff).
- `Spectrum`: end-to-end image download, invalid group, invalid order (proves the `AttributeError`→`ValueError` fix), missing-image → `FinvizParseError`, Wall → `FinvizBlockedError`.
- `ticker`: missing-NBSP span no longer `IndexError`s.

## Validation
`pytest test` → **99 passed** (was 93); `ruff check` clean; `ruff format --check` clean; `mypy` clean.

## Note for reviewers
finviz `groups.ashx` is Cloudflare-walled from my network, so the `group_spectrum` fixture is hand-authored (couldn't capture live). The "spectrum"-substring selector is my best inference of the real `spectrum.ashx` image URL; if live markup differs it now fails **loudly** as a typed `FinvizParseError` rather than the previous hard `AttributeError`/`IndexError`. The dead `out_dir` param passthrough — the call is `image_scrap(url, group, "")`, ignoring the method's `out_dir` — is a separate pre-existing issue left untouched to keep this change scoped to the crashes.
