### PR TITLE
build(deps): drop unused pyyaml dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dev = [
     "finvizfinance[test,docs]",
     "coverage>=7.5",
     "coveralls>=4.0",
-    "pyyaml>=6.0",
     "ruff>=0.6",
     "pre-commit>=3.5",
     "mypy>=1.8",


### PR DESCRIPTION
Low-risk repo/dependency hygiene. No runtime behavior change; public API and Python floor unchanged.

## Change
- **Drop the unused `pyyaml>=6.0` dev dependency** from `[project.optional-dependencies].dev`. It is a leftover — not imported anywhere in the package, `scripts/`, `test/`, docs, or CI (the only repo hit for "yaml" is unrelated prose in `docs/adr/0003-...md`).

## Verified already-clean (no change needed)
- **`dist/` build artifacts are not tracked.** `git ls-files` shows nothing under `dist/`, and `git log --all -- 'dist/*'` is empty (they were never committed). `.gitignore:13` already ignores `dist/` (the whole "Distribution / packaging" block is present). The local `dist/*.whl`/`*.tar.gz` on disk are ignored build output.
- **`xlsxwriter` kept as a core dependency.** It is used by `Earnings.output_excel` (`earnings.py:127-132`, `pd.ExcelWriter(engine="xlsxwriter")`); moving it to an optional extra would silently break existing callers, so it stays in `[project].dependencies`.

## Validation
- `pyproject.toml` parses; `dev` extra no longer contains `pyyaml`.
- Packaging still builds: hatchling `build_wheel` produces `finvizfinance-1.4.0-py3-none-any.whl` cleanly.
- `pytest test` → **93 passed**; `ruff check` clean; `mypy` clean.
