### PR TITLE
refactor: dedupe parsing into shared helpers; route stdout through logging

### DIFF
--- a/finvizfinance/__init__.py
+++ b/finvizfinance/__init__.py
@@ -7,5 +7,11 @@
 
 from __future__ import annotations
 
+import logging
+
+# Library convention: attach a NullHandler to the package's top-level logger so
+# finvizfinance never emits log output unless the application configures logging.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
 __version__ = "1.4.0"
 __author__ = "Tianning Li"

--- a/finvizfinance/__init__.py
+++ b/finvizfinance/__init__.py
@@ -5,5 +5,7 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 __version__ = "1.4.0"
 __author__ = "Tianning Li"

--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -7,13 +7,12 @@
 
 from __future__ import annotations
 
-import json
 import re
 
 import pandas as pd
 
 from finvizfinance.exceptions import FinvizParseError
-from finvizfinance.util import warn_missing, web_scrap
+from finvizfinance.util import decode_json_after, warn_missing, web_scrap
 
 CALENDAR_URL = "https://finviz.com/calendar.ashx"
 
@@ -26,14 +25,9 @@ def _script_json(soup, function_name):
         match = marker.search(text)
         if match is None:
             continue
-        start = match.end()
-        decoder = json.JSONDecoder()
-        try:
-            data, _ = decoder.raw_decode(text[start:].lstrip())
-        except (json.JSONDecodeError, TypeError) as err:
-            raise FinvizParseError(
-                url=CALENDAR_URL, selector=f"script: {function_name}(...)"
-            ) from err
+        data = decode_json_after(
+            text, match.end(), CALENDAR_URL, f"script: {function_name}(...)"
+        )
         if isinstance(data, list):
             return data
     return None

--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 import json
 import re
 

--- a/finvizfinance/earnings.py
+++ b/finvizfinance/earnings.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 import os
 
 import pandas as pd

--- a/finvizfinance/earnings.py
+++ b/finvizfinance/earnings.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 
 import pandas as pd
@@ -18,6 +19,8 @@ from finvizfinance.screener.ownership import Ownership
 from finvizfinance.screener.performance import Performance
 from finvizfinance.screener.technical import Technical
 from finvizfinance.screener.valuation import Valuation
+
+logger = logging.getLogger(__name__)
 
 
 class Earnings:
@@ -125,7 +128,7 @@ class Earnings:
         Args:
             output_file(str): name of the output excel file.
         """
-        print("Print to Excel...")
+        logger.info("Writing earnings to Excel...")
         with pd.ExcelWriter(  # pylint: disable=abstract-class-instantiated
             output_file, datetime_format="YYYY-MM-DD", engine="xlsxwriter"
         ) as writer:
@@ -139,7 +142,7 @@ class Earnings:
         Args:
             output_dir(str): name of the output directory.
         """
-        print("Print to CSV...")
+        logger.info("Writing earnings to CSV...")
         isdir = os.path.isdir(output_dir)
         if not isdir:
             os.mkdir(output_dir)

--- a/finvizfinance/exceptions.py
+++ b/finvizfinance/exceptions.py
@@ -18,6 +18,8 @@ types that previously propagated from that code path, so existing downstream
   ``raise_for_status`` on a 403). ``FinvizBlockedError`` subclasses that.
 """
 
+from __future__ import annotations
+
 import requests
 
 

--- a/finvizfinance/future.py
+++ b/finvizfinance/future.py
@@ -7,13 +7,12 @@
 
 from __future__ import annotations
 
-import json
 import re
 
 import pandas as pd
 
 from finvizfinance.exceptions import FinvizParseError
-from finvizfinance.util import web_scrap
+from finvizfinance.util import decode_json_after, web_scrap
 
 FUTURES_URL = "https://finviz.com/futures_performance.ashx"
 
@@ -29,13 +28,9 @@ def _extract_rows(soup):
         match = re.search(pattern, html)
         if match is None:
             continue
-        try:
-            data, _ = json.JSONDecoder().raw_decode(html[match.end() :].lstrip())
-        except json.JSONDecodeError as err:
-            raise FinvizParseError(
-                url=FUTURES_URL, selector="futures performance JSON"
-            ) from err
-        return data
+        return decode_json_after(
+            html, match.end(), FUTURES_URL, "futures performance JSON"
+        )
     raise FinvizParseError(url=FUTURES_URL, selector="futures performance JSON")
 
 

--- a/finvizfinance/future.py
+++ b/finvizfinance/future.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 import json
 import re
 

--- a/finvizfinance/group/__init__.py
+++ b/finvizfinance/group/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from finvizfinance.group.custom import Custom
 from finvizfinance.group.overview import Overview
 from finvizfinance.group.performance import Performance

--- a/finvizfinance/group/base.py
+++ b/finvizfinance/group/base.py
@@ -7,10 +7,8 @@
 
 from __future__ import annotations
 
-import pandas as pd
-
 from finvizfinance.constants import group_dict, group_order_dict
-from finvizfinance.util import number_convert, require, validate_choice, web_scrap
+from finvizfinance.util import scrap_group_table, validate_choice, web_scrap
 
 
 class Base:
@@ -52,25 +50,4 @@ class Base:
         self._parse_columns(columns)
 
         soup = web_scrap(self.url, self.request_params)
-        table = require(
-            soup.find("table", class_="groups_table"),
-            self.url,
-            "table.groups_table",
-        )
-        rows = table.find_all("tr")
-        table_header = [i.text.strip() for i in rows[0].find_all("th")][1:]
-        frame = []
-        rows = rows[1:]
-        num_col_index = list(range(2, len(table_header)))
-        for row in rows:
-            cols = row.find_all("td")[1:]
-            info_dict = {}
-            for i, col in enumerate(cols):
-                # check if the col is number
-                if i not in num_col_index:
-                    info_dict[table_header[i]] = col.text
-                else:
-                    info_dict[table_header[i]] = number_convert(col.text)
-
-            frame.append(info_dict)
-        return pd.DataFrame(frame)
+        return scrap_group_table(soup, self.url)

--- a/finvizfinance/group/base.py
+++ b/finvizfinance/group/base.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pandas as pd
 
 from finvizfinance.constants import group_dict, group_order_dict
-from finvizfinance.util import number_convert, require, web_scrap
+from finvizfinance.util import number_convert, require, validate_choice, web_scrap
 
 
 class Base:
@@ -41,16 +41,8 @@ class Base:
         Returns:
             df(pandas.DataFrame): group information table.
         """
-        if group not in group_dict:
-            group_keys = list(group_dict.keys())
-            raise ValueError(
-                f"Invalid group parameter '{group}'. Possible parameter input: {group_keys}"
-            )
-        if order not in group_order_dict:
-            order_keys = list(group_order_dict.keys())
-            raise ValueError(
-                f"Invalid order parameter '{order}'. Possible parameter input: {order_keys}"
-            )
+        validate_choice(group, group_dict, "group")
+        validate_choice(order, group_order_dict, "order")
 
         self.request_params = {
             **self.request_params,

--- a/finvizfinance/group/custom.py
+++ b/finvizfinance/group/custom.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.group.base import Base
 
 

--- a/finvizfinance/group/overview.py
+++ b/finvizfinance/group/overview.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.group.base import Base
 
 

--- a/finvizfinance/group/performance.py
+++ b/finvizfinance/group/performance.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.group.base import Base
 
 

--- a/finvizfinance/group/spectrum.py
+++ b/finvizfinance/group/spectrum.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from urllib.parse import urljoin
 
 from finvizfinance.constants import group_dict, group_order_dict

--- a/finvizfinance/group/spectrum.py
+++ b/finvizfinance/group/spectrum.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 
 from finvizfinance.constants import group_dict, group_order_dict
 from finvizfinance.group.base import Base
-from finvizfinance.util import image_scrap, require, web_scrap
+from finvizfinance.util import image_scrap, require, validate_choice, web_scrap
 
 
 class Spectrum(Base):
@@ -28,16 +28,8 @@ class Spectrum(Base):
             group(str): choice of group option.
             order(str): sort the table by the choice of order.
         """
-        if group not in group_dict:
-            group_keys = list(group_dict.keys())
-            raise ValueError(
-                f"Invalid group parameter '{group}'. Possible parameter input: {group_keys}"
-            )
-        if order not in group_order_dict:
-            order_keys = list(group_order_dict.keys())
-            raise ValueError(
-                f"Invalid order parameter '{order}'. Possible parameter input: {order_keys}"
-            )
+        validate_choice(group, group_dict, "group")
+        validate_choice(order, group_order_dict, "order")
 
         self.request_params.update(group_dict[group])
         self.request_params["o"] = group_order_dict[order]

--- a/finvizfinance/group/util.py
+++ b/finvizfinance/group/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from finvizfinance.constants import group_dict, group_order_dict
 
 

--- a/finvizfinance/group/valuation.py
+++ b/finvizfinance/group/valuation.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.group.base import Base
 
 

--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from finvizfinance.util import find_table_by_headers, number_convert, web_scrap
+from finvizfinance.util import find_table_by_headers, row_to_dict, web_scrap
 
 INSIDER_URL = "https://finviz.com/insidertrading"
 
@@ -71,19 +71,13 @@ class Insider:
             "SEC Form 4 Link"
         ]
         frame = []
-        rows = rows[1:]
         num_col = ["Cost", "#Shares", "Value ($)", "#Shares Total"]
         num_col_index = [table_header.index(i) for i in table_header if i in num_col]
-        for row in rows:
+        for row in rows[1:]:
             cols = row.find_all("td")
             if len(cols) < 5:
                 continue
-            info_dict = {}
-            for i, col in enumerate(cols):
-                if i not in num_col_index:
-                    info_dict[table_header[i]] = col.text
-                else:
-                    info_dict[table_header[i]] = number_convert(col.text)
+            info_dict = row_to_dict(cols, table_header, num_col_index)
             link = cols[-1].find("a")
             info_dict["SEC Form 4 Link"] = link.attrs["href"] if link else None
             frame.append(info_dict)

--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 import pandas as pd
 
 from finvizfinance.util import find_table_by_headers, number_convert, web_scrap

--- a/finvizfinance/news.py
+++ b/finvizfinance/news.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 import pandas as pd
 
 from finvizfinance.exceptions import FinvizParseError

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -20,6 +20,7 @@ from finvizfinance.util import (
     number_convert,
     optional,
     require,
+    validate_choice,
     warn_missing,
     web_scrap,
     web_scrap_json,
@@ -173,12 +174,7 @@ class finvizfinance:
         Returns:
             fundament(dict): ticker fundament.
         """
-        if output_format not in ["dict", "series"]:
-            raise ValueError(
-                "Invalid output format '{}'. Possible choice: {}".format(
-                    output_format, ["dict", "series"]
-                )
-            )
+        validate_choice(output_format, ["dict", "series"], "output format")
         fundament_info = {}
 
         fundament_info["Company"] = require(

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import date, datetime
 
@@ -23,6 +24,8 @@ from finvizfinance.util import (
     web_scrap,
     web_scrap_json,
 )
+
+logger = logging.getLogger(__name__)
 
 QUOTE_URL = "https://finviz.com/quote.ashx?t={ticker}"
 NUM_COL = [
@@ -80,10 +83,10 @@ class finvizfinance:
     def _checkexist(self, verbose):
         body = self.soup.find("td", class_="body-text")
         if body is not None and "not found" in body.text:
-            print("Ticker not found.")
+            logger.warning("Ticker not found.")
             return False
         if verbose == 1:
-            print("Ticker exists.")
+            logger.info("Ticker exists.")
         return True
 
     def ticker_charts(

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 import re
 from datetime import date, datetime
 

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -20,6 +20,7 @@ from finvizfinance.util import (
     number_convert,
     optional,
     require,
+    row_to_dict,
     validate_choice,
     warn_missing,
     web_scrap,
@@ -423,17 +424,11 @@ class finvizfinance:
         table_header = [i.text for i in rows[0].find_all("th")]
         table_header += ["SEC Form 4 Link", "Insider_id"]
         frame = []
-        rows = rows[1:]
         num_col = ["Cost", "#Shares", "Value ($)", "#Shares Total"]
         num_col_index = [table_header.index(i) for i in table_header if i in num_col]
-        for row in rows:
+        for row in rows[1:]:
             cols = row.find_all("td")
-            info_dict = {}
-            for i, col in enumerate(cols):
-                if i not in num_col_index:
-                    info_dict[table_header[i]] = col.text
-                else:
-                    info_dict[table_header[i]] = number_convert(col.text)
+            info_dict = row_to_dict(cols, table_header, num_col_index)
             info_dict["SEC Form 4 Link"] = cols[-1].find("a").attrs["href"]
             info_dict["Insider_id"] = cols[0].a["href"].split("oc=")[1].split("&tc=")[0]
             frame.append(info_dict)

--- a/finvizfinance/screener/__init__.py
+++ b/finvizfinance/screener/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from finvizfinance.screener.custom import Custom
 from finvizfinance.screener.financial import Financial
 from finvizfinance.screener.overview import Overview

--- a/finvizfinance/screener/base.py
+++ b/finvizfinance/screener/base.py
@@ -20,6 +20,7 @@ from finvizfinance.util import (
     number_convert,
     progress_bar,
     require,
+    validate_choice,
     web_scrap,
 )
 
@@ -48,11 +49,7 @@ class Base:
         """
         if not signal:
             return
-        if signal not in signal_dict:
-            signal_keys = list(signal_dict.keys())
-            raise ValueError(
-                f"Invalid signal '{signal}'. Possible signal: {signal_keys}"
-            )
+        validate_choice(signal, signal_dict, "signal")
         self.request_params["s"] = signal_dict[signal]
 
     def _set_filters(self, filters_dict):
@@ -66,16 +63,8 @@ class Base:
         """
         filters = []
         for key, value in filters_dict.items():
-            if key not in filter_dict:
-                filter_keys = list(filter_dict.keys())
-                raise ValueError(
-                    f"Invalid filter '{key}'. Possible filter: {filter_keys}"
-                )
-            if value not in filter_dict[key]["option"]:
-                filter_options = list(filter_dict[key]["option"].keys())
-                raise ValueError(
-                    f"Invalid filter option '{value}'. Possible filter options: {filter_options}"
-                )
+            validate_choice(key, filter_dict, "filter")
+            validate_choice(value, filter_dict[key]["option"], "filter option")
             prefix = filter_dict[key]["prefix"]
             urlcode = filter_dict[key]["option"][value]
             if urlcode != "":
@@ -208,9 +197,7 @@ class Base:
         Returns:
             df(pandas.DataFrame): screener information table
         """
-        if order not in order_dict:
-            order_keys = list(order_dict.keys())
-            raise ValueError(f"Invalid order '{order}'. Possible order: {order_keys}")
+        validate_choice(order, order_dict, "order")
         self.request_params["o"] = ("" if ascend else "-") + order_dict[order]
 
         if select_page:

--- a/finvizfinance/screener/base.py
+++ b/finvizfinance/screener/base.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from time import sleep
 
@@ -21,6 +22,8 @@ from finvizfinance.util import (
     require,
     web_scrap,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class Base:
@@ -219,7 +222,7 @@ class Base:
 
         page = self._get_page(soup)
         if page == 0:
-            print("No ticker found.")
+            logger.warning("No ticker found.")
             return None
         df = self._parse_table(None, soup, limit)
         limit -= self.size

--- a/finvizfinance/screener/custom.py
+++ b/finvizfinance/screener/custom.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.screener.base import Base
 
 

--- a/finvizfinance/screener/financial.py
+++ b/finvizfinance/screener/financial.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.screener.base import Base
 
 

--- a/finvizfinance/screener/overview.py
+++ b/finvizfinance/screener/overview.py
@@ -6,6 +6,8 @@
 
 """
 
+from __future__ import annotations
+
 from finvizfinance.screener.base import Base
 
 

--- a/finvizfinance/screener/ownership.py
+++ b/finvizfinance/screener/ownership.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.screener.base import Base
 
 

--- a/finvizfinance/screener/performance.py
+++ b/finvizfinance/screener/performance.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.screener.base import Base
 
 

--- a/finvizfinance/screener/technical.py
+++ b/finvizfinance/screener/technical.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.screener.base import Base
 
 

--- a/finvizfinance/screener/ticker.py
+++ b/finvizfinance/screener/ticker.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from time import sleep
 
 from finvizfinance.constants import order_dict

--- a/finvizfinance/screener/ticker.py
+++ b/finvizfinance/screener/ticker.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import logging
 from time import sleep
 
 from finvizfinance.constants import order_dict
@@ -16,6 +17,8 @@ from finvizfinance.util import (
     require,
     web_scrap,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class Ticker(Base):
@@ -62,7 +65,7 @@ class Ticker(Base):
         soup = web_scrap(self.url, self.request_params)
         page = self._get_page(soup)
         if page == 0:
-            print("No ticker found.")
+            logger.warning("No ticker found.")
             return None
 
         if limit != -1 and page > (limit - 1) // 1000 + 1:

--- a/finvizfinance/screener/ticker.py
+++ b/finvizfinance/screener/ticker.py
@@ -15,6 +15,7 @@ from finvizfinance.screener.base import Base
 from finvizfinance.util import (
     progress_bar,
     require,
+    validate_choice,
     web_scrap,
 )
 
@@ -58,9 +59,7 @@ class Ticker(Base):
         Returns:
             tickers(list): get all the tickers as list.
         """
-        if order not in order_dict:
-            order_keys = list(order_dict.keys())
-            raise ValueError(f"Invalid order '{order}'. Possible order: {order_keys}")
+        validate_choice(order, order_dict, "order")
         self.request_params["o"] = ("" if ascend else "-") + order_dict[order]
         soup = web_scrap(self.url, self.request_params)
         page = self._get_page(soup)

--- a/finvizfinance/screener/util.py
+++ b/finvizfinance/screener/util.py
@@ -6,6 +6,7 @@ from finvizfinance.constants import (
     order_dict,
     signal_dict,
 )
+from finvizfinance.util import validate_choice
 
 
 def get_signal():
@@ -35,11 +36,7 @@ def get_filter_options(screen_filter):
     Returns:
         filter_options(list): all the available filters
     """
-    if screen_filter not in filter_dict:
-        filter_keys = list(filter_dict.keys())
-        raise ValueError(
-            f"Invalid filter '{screen_filter}'. Possible filter: {filter_keys}"
-        )
+    validate_choice(screen_filter, filter_dict, "filter")
     return list(filter_dict[screen_filter]["option"])
 
 

--- a/finvizfinance/screener/util.py
+++ b/finvizfinance/screener/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from finvizfinance.constants import (
     CUSTOM_SCREENER_COLUMNS,
     filter_dict,

--- a/finvizfinance/screener/valuation.py
+++ b/finvizfinance/screener/valuation.py
@@ -5,6 +5,8 @@
 .. moduleauthor:: Tianning Li <ltianningli@gmail.com>
 """
 
+from __future__ import annotations
+
 from finvizfinance.screener.base import Base
 
 

--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -301,6 +301,49 @@ def find_table_by_headers(
     raise FinvizParseError(url=url, selector=selector)
 
 
+def row_to_dict(
+    cols: Any, table_header: list[str], num_col_index: list[int]
+) -> dict[str, Any]:
+    """Build a header-keyed row dict from a table row's ``<td>`` cells.
+
+    Columns whose index is in ``num_col_index`` are passed through
+    :func:`number_convert`; the rest keep their raw text. Shared by the group,
+    insider, and quote insider-trader parsers.
+
+    Args:
+        cols: the row's ``<td>`` cells.
+        table_header(list): column names, indexed positionally against ``cols``.
+        num_col_index(list): indices of the numeric columns.
+    """
+    info: dict[str, Any] = {}
+    for i, col in enumerate(cols):
+        text = col.text
+        info[table_header[i]] = number_convert(text) if i in num_col_index else text
+    return info
+
+
+def scrap_group_table(soup: Any, url: str) -> pd.DataFrame:
+    """Parse a finviz ``groups_table`` into a DataFrame (header-keyed columns).
+
+    Args:
+        soup(beautiful soup): parsed groups page.
+        url(str): the URL being parsed (for the error message).
+    Returns:
+        df(pandas.DataFrame): group information table.
+    """
+    table = require(
+        soup.find("table", class_="groups_table"), url, "table.groups_table"
+    )
+    rows = table.find_all("tr")
+    table_header = [i.text.strip() for i in rows[0].find_all("th")][1:]
+    num_col_index = list(range(2, len(table_header)))
+    frame = [
+        row_to_dict(row.find_all("td")[1:], table_header, num_col_index)
+        for row in rows[1:]
+    ]
+    return pd.DataFrame(frame)
+
+
 def scrap_function(url: str) -> pd.DataFrame:
     """Scrap forex, crypto information.
 
@@ -309,25 +352,7 @@ def scrap_function(url: str) -> pd.DataFrame:
     Returns:
         df(pandas.DataFrame): performance table
     """
-    soup = web_scrap(url)
-    table = require(
-        soup.find("table", class_="groups_table"), url, "table.groups_table"
-    )
-    rows = table.find_all("tr")
-    table_header = [i.text.strip() for i in rows[0].find_all("th")][1:]
-    frame: list[dict[str, Any]] = []
-    rows = rows[1:]
-    num_col_index = list(range(2, len(table_header)))
-    for row in rows:
-        cols = row.find_all("td")[1:]
-        info_dict: dict[str, Any] = {}
-        for i, col in enumerate(cols):
-            if i not in num_col_index:
-                info_dict[table_header[i]] = col.text
-            else:
-                info_dict[table_header[i]] = number_convert(col.text)
-        frame.append(info_dict)
-    return pd.DataFrame(frame)
+    return scrap_group_table(web_scrap(url), url)
 
 
 def image_scrap_function(

--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -301,6 +301,27 @@ def find_table_by_headers(
     raise FinvizParseError(url=url, selector=selector)
 
 
+def decode_json_after(text: str, start: int, url: str, selector: str) -> Any:
+    """Raw-decode a JSON value embedded in ``text`` starting at ``start``.
+
+    Shared by the calendar and futures parsers to pull the JSON argument out
+    of a finviz client-side init script (e.g. ``FinvizInit...([...])``). Raises
+    :class:`FinvizParseError` when the slice does not begin with valid JSON (a
+    finviz Drift).
+
+    Args:
+        text(str): the surrounding text (a script body or prettified HTML).
+        start(int): offset in ``text`` at which the JSON value begins.
+        url(str): the URL being parsed (for the error message).
+        selector(str): a human-readable description for the error message.
+    """
+    try:
+        data, _ = json.JSONDecoder().raw_decode(text[start:].lstrip())
+    except (json.JSONDecodeError, TypeError) as err:
+        raise FinvizParseError(url=url, selector=selector) from err
+    return data
+
+
 def row_to_dict(
     cols: Any, table_header: list[str], num_col_index: list[int]
 ) -> dict[str, Any]:

--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import json
-import sys
+import logging
 import time
 import warnings
 from datetime import date, datetime
@@ -23,6 +23,8 @@ from finvizfinance.exceptions import (  # noqa: F401  (re-exported for convenien
     FinvizError,
     FinvizParseError,
 )
+
+logger = logging.getLogger(__name__)
 
 # A current browser User-Agent. A trivially-outdated client string (the old
 # 2020 Chrome/81) is an easy flag for anti-bot heuristics.
@@ -399,8 +401,4 @@ def format_datetime(date_str: str) -> datetime:
 
 
 def progress_bar(page: int, total: int) -> None:
-    bar_len = 30
-    filled_len = int(round(bar_len * page / float(total)))
-    bar = "#" * filled_len + "-" * (bar_len - filled_len)
-    sys.stdout.write(f"[Info] loading page [{bar}] {page}/{total} \r")
-    sys.stdout.flush()
+    logger.info("loading page %d/%d", page, total)

--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -250,6 +250,28 @@ def optional(node: Any, url: str, selector: str, default: Any = None) -> Any:
     return node
 
 
+def validate_choice(value: Any, options: Any, label: str) -> Any:
+    """Return ``value`` if it is a valid choice, else raise :class:`ValueError`.
+
+    Centralizes the "invalid parameter" guard duplicated across the screener
+    and group modules: it checks membership in ``options`` and, on failure,
+    raises a ``ValueError`` naming the offending value and listing the valid
+    keys.
+
+    Args:
+        value: the user-supplied choice.
+        options: the valid choices — a mapping whose keys are valid, or any
+            membership-testable container.
+        label(str): human-readable noun for the message, e.g. ``"order"``.
+    Returns:
+        the validated ``value`` (for optional chaining).
+    """
+    if value not in options:
+        valid = list(options)
+        raise ValueError(f"Invalid {label} '{value}'. Possible {label}: {valid}")
+    return value
+
+
 def find_table_by_headers(
     soup: Any, required_headers: list[str], url: str, selector: str
 ) -> Any:


### PR DESCRIPTION
Internal refactor + logging. **No public API change** (import paths, class/function names, signatures, and return shapes are unchanged); Python floor unchanged. Delivered as 5 focused commits, each keeping the offline suite green.

## What changed

**1. `from __future__ import annotations` everywhere.** Added to every module that lacked it *except* the pure-data `constants.py`. (Note: the campaign spec estimated "8 modules", but 26 actually lacked it — applied uniformly for consistency.)

**2. Route stdout side effects through `logging`.** Added a package-level `NullHandler` (on the `finvizfinance` logger) and per-module loggers, and replaced the six `print()` calls plus the `sys.stdout.write` progress bar with logging: "not found" → `logger.warning`, progress/export → `logger.info`.
- **Behavior note:** the library is now silent by default; progress and "ticker/no-ticker found"/export text no longer hit stdout unless the application configures logging.

**3. Centralize choice validation.** Replaced the duplicated `if x not in mapping: raise ValueError(...)` guards (signal, filter, filter option, order, group, output format) across screener/group with one `util.validate_choice(value, options, label)`. Error-message wording is now uniform (`Invalid <label> '<value>'. Possible <label>: [...]`); no test or public contract depends on the exact text (the one message-asserting test, `test_quote.py` `Invalid timeframe`, is a different site and untouched).

**4. Extract shared table helpers.** `util.row_to_dict` (header-keyed row builder w/ numeric conversion) and `util.scrap_group_table` (the `groups_table` parse):
- `scrap_function` and `group.Base.screener_view` were byte-identical → both now call `scrap_group_table`.
- `insider.get_insider` and `quote.ticker_inside_trader` build rows via `row_to_dict`, keeping their own extra columns (`SEC Form 4 Link`, `Insider_id`) and guards.

**5. Extract shared JSON-from-`<script>` decoder.** `util.decode_json_after` (raw-decode a JSON value, raising `FinvizParseError` on failure); `calendar._script_json` and `future._extract_rows` route through it while keeping their own marker search and return contracts.

## Scope note for reviewers
The 5 "table-scrape" copies have **4 distinct return contracts**, so I did **not** force them into a single helper — that would change frozen return shapes. Specifically `screener.Base._get_table` stays separate (positional/duplicate-column-safe with `data-boxover-ticker` + pagination), and the insider vs quote insider-trader parsers keep their differing columns/guards. I extracted the genuinely-shared primitives (`row_to_dict`, `scrap_group_table`, `decode_json_after`) instead.

Excluded per constraints: the 10 one-line `v_page` subclasses are **not** collapsed, and `constants.py` is **not** split.

## Validation
`pytest test` → **99 passed**; `ruff check` + `ruff format --check` clean; `mypy` clean; hatchling `build_wheel` succeeds; public entrypoints (incl. the deprecated `number_covert` alias) import unchanged. Net: 29 files, +195/−142.
