### PR TITLE
build(mypy): ratchet strictness (moderate) and annotate to satisfy it

### DIFF
--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 import pandas as pd
 
@@ -17,7 +18,7 @@ from finvizfinance.util import decode_json_after, warn_missing, web_scrap
 CALENDAR_URL = "https://finviz.com/calendar.ashx"
 
 
-def _script_json(soup, function_name):
+def _script_json(soup: Any, function_name: str) -> list[Any] | None:
     """Extract the JSON argument passed to a client-side init function."""
     marker = re.compile(rf"(?:window\.)?{re.escape(function_name)}\s*\(")
     for script in soup.find_all("script"):
@@ -36,10 +37,10 @@ def _script_json(soup, function_name):
 class Calendar:
     """Getting information from the finviz calendar page."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def calendar(self):
+    def calendar(self) -> pd.DataFrame:
         """Get economic calendar table."""
         soup = web_scrap(CALENDAR_URL)
         tables = soup.find_all("table", class_="calendar")
@@ -64,10 +65,10 @@ class Calendar:
         return pd.DataFrame(rows)
 
     @staticmethod
-    def _calendar_row(row):
+    def _calendar_row(row: Any) -> dict[str, Any]:
         """Normalize a client-rendered calendar object to the public columns."""
 
-        def value(*keys):
+        def value(*keys: str) -> Any:
             for key in keys:
                 if key in row:
                     return row[key]
@@ -88,7 +89,7 @@ class Calendar:
         }
 
     @staticmethod
-    def _calendar_tables(tables):
+    def _calendar_tables(tables: Any) -> pd.DataFrame:
         frame = []
         for table in tables:
             rows = table.find_all("tr")

--- a/finvizfinance/constants.py
+++ b/finvizfinance/constants.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 NUMBER_COL = [
     "Market Cap",
     "P/E",
@@ -185,7 +189,7 @@ CUSTOM_GROUP_COLUMNS = {
 }
 
 
-util_dict = {
+util_dict: dict[str, Any] = {
     "signal": {
         "Top Gainers": "ta_topgainers",
         "Top Losers": "ta_toplosers",
@@ -2325,7 +2329,7 @@ signal_dict = util_dict["signal"]
 filter_dict = util_dict["filter"]
 order_dict = util_dict["order"]
 
-group_util_dict = {
+group_util_dict: dict[str, Any] = {
     "group": {
         "Sector": {"g": "sector"},
         "Industry": {"g": "industry"},

--- a/finvizfinance/earnings.py
+++ b/finvizfinance/earnings.py
@@ -13,6 +13,7 @@ import os
 import pandas as pd
 
 from finvizfinance.exceptions import FinvizParseError
+from finvizfinance.screener.base import Base
 from finvizfinance.screener.financial import Financial
 from finvizfinance.screener.overview import Overview
 from finvizfinance.screener.ownership import Ownership
@@ -33,15 +34,15 @@ class Earnings:
                      Previous Week, This Month).
     """
 
-    def __init__(self, period="This Week"):
+    def __init__(self, period: str = "This Week") -> None:
         """initiate module"""
-        self.earning_days = []
-        self.df_days = {}
-        self.df = None
+        self.earning_days: list = []
+        self.df_days: dict = {}
+        self.df: pd.DataFrame = None
         self.period = period
         self._set_period(period)
 
-    def _set_period(self, period):
+    def _set_period(self, period: str) -> None:
         """Set the period.
 
         Args:
@@ -68,7 +69,7 @@ class Earnings:
         self.earning_days = list(set(self.df["Earnings"].to_list()))
         self.earning_days.sort()
 
-    def partition_days(self, mode="financial"):
+    def partition_days(self, mode: str = "financial") -> dict[str, pd.DataFrame]:
         """Partition dataframe to separate dataframes according to the dates.
 
         Args:
@@ -96,7 +97,7 @@ class Earnings:
                     "Ticker"
                 ].to_list()
 
-        fearnings = None
+        fearnings: Base | None = None
         if mode == "financial":
             return self.df_days
         elif mode == "overview":
@@ -111,9 +112,10 @@ class Earnings:
             fearnings = Technical()
 
         filters_dict = {"Earnings Date": self.period}
+        assert fearnings is not None  # a non-financial mode is always set above
         fearnings.set_filter(filters_dict=filters_dict)
         df2 = fearnings.screener_view(order="Earnings Date", verbose=0)
-        df2_days = {}
+        df2_days: dict = {}
         for earning_day in self.earning_days:
             tickers = self.df_days[earning_day]
             df2_days[earning_day] = df2[df2["Ticker"].isin(tickers)].reset_index(
@@ -122,7 +124,7 @@ class Earnings:
         self.df_days = df2_days
         return self.df_days
 
-    def output_excel(self, output_file="earning_days.xlsx"):
+    def output_excel(self, output_file: str = "earning_days.xlsx") -> None:
         """Output dataframes to single Excel file.
 
         Args:
@@ -136,7 +138,7 @@ class Earnings:
                 sheet_name = "_".join(name.split("/"))
                 df.to_excel(writer, sheet_name=sheet_name, index=False)
 
-    def output_csv(self, output_dir="earning_days"):
+    def output_csv(self, output_dir: str = "earning_days") -> None:
         """Output dataframes to csv files.
 
         Args:

--- a/finvizfinance/exceptions.py
+++ b/finvizfinance/exceptions.py
@@ -34,7 +34,12 @@ class FinvizParseError(FinvizError, AttributeError, IndexError, KeyError, TypeEr
     Carries the ``url`` and the failed ``selector`` so Drift can be diagnosed.
     """
 
-    def __init__(self, message=None, url=None, selector=None):
+    def __init__(
+        self,
+        message: str | None = None,
+        url: str | None = None,
+        selector: str | None = None,
+    ) -> None:
         self.url = url
         self.selector = selector
         if message is None:
@@ -54,7 +59,7 @@ class FinvizBlockedError(FinvizError, requests.exceptions.HTTPError):
     ``url``.
     """
 
-    def __init__(self, message=None, url=None):
+    def __init__(self, message: str | None = None, url: str | None = None) -> None:
         self.url = url
         if message is None:
             message = (

--- a/finvizfinance/future.py
+++ b/finvizfinance/future.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 import pandas as pd
 
@@ -17,7 +18,7 @@ from finvizfinance.util import decode_json_after, web_scrap
 FUTURES_URL = "https://finviz.com/futures_performance.ashx"
 
 
-def _extract_rows(soup):
+def _extract_rows(soup: Any) -> Any:
     """Extract rows from either the legacy or current init call."""
     html = soup.prettify()
     patterns = [
@@ -37,10 +38,10 @@ def _extract_rows(soup):
 class Future:
     """Getting information from the finviz future page."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def performance(self, timeframe="D"):
+    def performance(self, timeframe: str = "D") -> pd.DataFrame:
         """Get futures performance table."""
         timeframe_dict = {"W": 12, "M": 13, "Q": 14, "HY": 15, "Y": 16}
         params = {}

--- a/finvizfinance/group/base.py
+++ b/finvizfinance/group/base.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import pandas as pd
+
 from finvizfinance.constants import group_dict, group_order_dict
 from finvizfinance.util import scrap_group_table, validate_choice, web_scrap
 
@@ -20,16 +22,18 @@ class Base:
     url = "https://finviz.com/groups.ashx"
     request_params: dict = {}
 
-    def __init__(self):
+    def __init__(self) -> None:
         """initiate module"""
         self.request_params = {
             "v": self.v_page,
         }
 
-    def _parse_columns(self, columns):
+    def _parse_columns(self, columns: list | None) -> None:
         return
 
-    def screener_view(self, group="Sector", order="Name", columns=None):
+    def screener_view(
+        self, group: str = "Sector", order: str = "Name", columns: list | None = None
+    ) -> pd.DataFrame:
         """Get screener table.
 
         Args:

--- a/finvizfinance/group/custom.py
+++ b/finvizfinance/group/custom.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import pandas as pd
+
 from finvizfinance.group.base import Base
 
 
@@ -17,13 +19,15 @@ class Custom(Base):
 
     v_page = 152
 
-    def _parse_columns(self, columns):
+    def _parse_columns(self, columns: list | None) -> None:
         if not columns:
             return
         columns = [str(i) for i in columns]
         self.request_params["c"] = ",".join(columns)
 
-    def screener_view(self, group="Sector", order="Name", columns=None):
+    def screener_view(
+        self, group: str = "Sector", order: str = "Name", columns: list | None = None
+    ) -> pd.DataFrame:
         """Get screener table.
 
         Args:

--- a/finvizfinance/group/spectrum.py
+++ b/finvizfinance/group/spectrum.py
@@ -21,7 +21,9 @@ class Spectrum(Base):
 
     v_page = 310
 
-    def screener_view(self, group="Sector", order="Name", out_dir=""):
+    def screener_view(  # type: ignore[override]  # public API intentionally differs from Base
+        self, group: str = "Sector", order: str = "Name", out_dir: str = ""
+    ) -> None:
         """Get screener table.
 
         Args:

--- a/finvizfinance/group/util.py
+++ b/finvizfinance/group/util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from finvizfinance.constants import group_dict, group_order_dict
 
 
-def get_group():
+def get_group() -> list[str]:
     """Get groups.
 
     Returns:
@@ -12,7 +12,7 @@ def get_group():
     return list(group_dict.keys())
 
 
-def get_orders():
+def get_orders() -> list[str]:
     """Get orders.
 
     Returns:

--- a/finvizfinance/insider.py
+++ b/finvizfinance/insider.py
@@ -36,7 +36,7 @@ class Insider:
                       top owner sales, insider_id)
     """
 
-    def __init__(self, option="latest"):
+    def __init__(self, option: str = "latest") -> None:
         """initiate module"""
         if option in OPTION_QUERY:
             self.url = INSIDER_URL + OPTION_QUERY[option]
@@ -51,7 +51,7 @@ class Insider:
         self.soup = web_scrap(self.url)
         self.df = None
 
-    def get_insider(self):
+    def get_insider(self) -> pd.DataFrame:
         """Get insider information table.
 
         Returns:

--- a/finvizfinance/news.py
+++ b/finvizfinance/news.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pandas as pd
 
 from finvizfinance.exceptions import FinvizParseError
@@ -20,13 +22,13 @@ class News:
     Getting information from the finviz news page.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """initiate module"""
-        self.all_news = {}
+        self.all_news: dict = {}
         self.soup = web_scrap(NEWS_URL)
-        self.news = {}
+        self.news: dict[str, pd.DataFrame] = {}
 
-    def get_news(self):
+    def get_news(self) -> dict[str, pd.DataFrame]:
         """Get insider information table.
 
         Retrieves table information from finviz finance news.
@@ -50,7 +52,7 @@ class News:
         self.news = {"news": news_df, "blogs": blog_df}
         return self.news
 
-    def _get_news_helper(self, rows):
+    def _get_news_helper(self, rows: Any) -> pd.DataFrame:
         """Get insider information table helper function.
 
         Args:

--- a/finvizfinance/quote.py
+++ b/finvizfinance/quote.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import re
 from datetime import date, datetime
+from typing import Any
 
 import pandas as pd
 
@@ -48,14 +49,14 @@ class Quote:
 
     """
 
-    def get_current(self, ticker):
+    def get_current(self, ticker: str) -> str:
         """Getting current price of the ticker.
 
         Returns:
             price(float): price of the ticker
         """
         soup = web_scrap(f"https://finviz.com/request_quote.ashx?t={ticker}")
-        return soup.text
+        return str(soup.text)
 
 
 class finvizfinance:
@@ -69,9 +70,9 @@ class finvizfinance:
 
     def __init__(
         self,
-        ticker,
-        verbose=0,
-    ):
+        ticker: str,
+        verbose: int = 0,
+    ) -> None:
         """initiate module"""
 
         self.ticker = ticker
@@ -80,9 +81,9 @@ class finvizfinance:
         self.soup = web_scrap(self.quote_url)
         if self._checkexist(verbose):
             self.flag = True
-        self.info = {}
+        self.info: dict = {}
 
-    def _checkexist(self, verbose):
+    def _checkexist(self, verbose: int) -> bool:
         body = self.soup.find("td", class_="body-text")
         if body is not None and "not found" in body.text:
             logger.warning("Ticker not found.")
@@ -92,8 +93,12 @@ class finvizfinance:
         return True
 
     def ticker_charts(
-        self, timeframe="daily", charttype="advanced", out_dir="", urlonly=False
-    ):
+        self,
+        timeframe: str = "daily",
+        charttype: str = "advanced",
+        out_dir: str = "",
+        urlonly: bool = False,
+    ) -> str:
         """Download ticker charts.
 
         Args:
@@ -128,7 +133,7 @@ class finvizfinance:
             image_scrap(chart_url, self.ticker, out_dir)
         return chart_url
 
-    def _extract_classification(self):
+    def _extract_classification(self) -> dict[str, str | None]:
         """Sector / Industry / Country / Exchange from the quote-links region.
 
         These are optional (an ETF has none). Resilient to the region being
@@ -136,7 +141,7 @@ class finvizfinance:
         finally returns ``None`` with a warning for anything genuinely absent.
         """
         keys = ["Sector", "Industry", "Country", "Exchange"]
-        result = dict.fromkeys(keys)
+        result: dict[str, str | None] = dict.fromkeys(keys)
 
         quote_links = self.soup.find("div", class_="quote-links")
         if quote_links is not None:
@@ -165,7 +170,9 @@ class finvizfinance:
                 warn_missing(self.quote_url, f"quote classification link ({key})")
         return result
 
-    def ticker_fundament(self, raw=True, output_format="dict"):
+    def ticker_fundament(
+        self, raw: bool = True, output_format: str = "dict"
+    ) -> dict | pd.DataFrame:
         """Get ticker fundament.
 
         Args:
@@ -176,7 +183,7 @@ class finvizfinance:
             fundament(dict): ticker fundament.
         """
         validate_choice(output_format, ["dict", "series"], "output format")
-        fundament_info = {}
+        fundament_info: dict = {}
 
         fundament_info["Company"] = require(
             self.soup.find("h2", class_="quote-header_ticker-wrapper_company"),
@@ -205,7 +212,7 @@ class finvizfinance:
             return fundament_info
         return pd.DataFrame.from_dict(fundament_info, orient="index", columns=["Stat"])
 
-    def _parse_column(self, cols, raw, fundament_info):
+    def _parse_column(self, cols: list[str], raw: bool, fundament_info: dict) -> dict:
         header = ""
         for i, value in enumerate(cols):
             if i % 2 == 0:
@@ -239,19 +246,31 @@ class finvizfinance:
                             fundament_info[header] = value
         return fundament_info
 
-    def _parse_52w_range(self, header, fundament_info, value, raw):
+    def _parse_52w_range(
+        self, header: str, fundament_info: dict, value: str, raw: bool
+    ) -> dict:
         info_header = ["52W Range From", "52W Range To"]
         info_value = [0, 2]
         self._parse_value(header, fundament_info, value, raw, info_header, info_value)
         return fundament_info
 
-    def _parse_volatility(self, header, fundament_info, value, raw):
+    def _parse_volatility(
+        self, header: str, fundament_info: dict, value: str, raw: bool
+    ) -> dict:
         info_header = ["Volatility W", "Volatility M"]
         info_value = [0, 1]
         self._parse_value(header, fundament_info, value, raw, info_header, info_value)
         return fundament_info
 
-    def _parse_value(self, header, fundament_info, value, raw, info_header, info_value):
+    def _parse_value(
+        self,
+        header: str,
+        fundament_info: dict,
+        value: Any,
+        raw: bool,
+        info_header: list[str],
+        info_value: list[int],
+    ) -> dict:
         value = value.split()
         if len(value) <= max(info_value):
             # Unexpected shape for this datum; keep the raw split, do not crash.
@@ -265,20 +284,22 @@ class finvizfinance:
                 fundament_info[info_header[i]] = number_convert(value[value_index])
         return fundament_info
 
-    def ticker_description(self):
+    def ticker_description(self) -> str:
         """Get ticker description.
 
         Returns:
             description(str): ticker description.
         """
-        return require(
-            self.soup.find("td", class_="fullview-profile")
-            or self.soup.find(class_="fullview-profile"),
-            self.quote_url,
-            "fullview-profile",
-        ).text
+        return str(
+            require(
+                self.soup.find("td", class_="fullview-profile")
+                or self.soup.find(class_="fullview-profile"),
+                self.quote_url,
+                "fullview-profile",
+            ).text
+        )
 
-    def _ticker_list_from_link(self, label, selector):
+    def _ticker_list_from_link(self, label: str, selector: str) -> list[str]:
         """Extract a comma-separated ticker list from a quote-page link.
 
         Finds an anchor whose visible text is ``label`` (case-insensitive) and
@@ -300,7 +321,7 @@ class finvizfinance:
         tickers_part = href.split("t=")[-1]
         return [t.strip() for t in tickers_part.split(",") if t.strip()]
 
-    def ticker_peer(self):
+    def ticker_peer(self) -> list[str]:
         """Get peer tickers for the given ticker.
 
         Returns:
@@ -308,7 +329,7 @@ class finvizfinance:
         """
         return self._ticker_list_from_link("Peers", "Peers link")
 
-    def ticker_etf_holders(self):
+    def ticker_etf_holders(self) -> list[str]:
         """Get ETFs that hold the given ticker.
 
         Returns:
@@ -317,7 +338,7 @@ class finvizfinance:
         """
         return self._ticker_list_from_link("Held by", "Held by link")
 
-    def ticker_outer_ratings(self):
+    def ticker_outer_ratings(self) -> pd.DataFrame | None:
         """Get outer ratings table.
 
         Returns:
@@ -360,7 +381,7 @@ class finvizfinance:
         self.info["ratings_outer"] = df
         return df
 
-    def ticker_news(self):
+    def ticker_news(self) -> pd.DataFrame | None:
         """Get news information table.
 
         Returns:
@@ -406,7 +427,7 @@ class finvizfinance:
         self.info["news"] = df
         return df
 
-    def ticker_inside_trader(self):
+    def ticker_inside_trader(self) -> pd.DataFrame | None:
         """Get insider information table.
 
         Returns:
@@ -436,7 +457,7 @@ class finvizfinance:
         self.info["inside trader"] = df
         return df
 
-    def ticker_signal(self):
+    def ticker_signal(self) -> list[str]:
         """Get all the trading signals from finviz.
 
         Returns:
@@ -490,7 +511,7 @@ class finvizfinance:
                 ticker_signal.append(signal)
         return ticker_signal
 
-    def ticker_full_info(self):
+    def ticker_full_info(self) -> dict:
         """Get all the ticker information.
 
         Returns:
@@ -509,7 +530,9 @@ class Statements:
 
     """
 
-    def get_statements(self, ticker, statement="I", timeframe="A"):
+    def get_statements(
+        self, ticker: str, statement: str = "I", timeframe: str = "A"
+    ) -> pd.DataFrame:
         """Getting statements of ticker.
 
         Args:

--- a/finvizfinance/screener/base.py
+++ b/finvizfinance/screener/base.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import warnings
 from time import sleep
+from typing import Any
 
 import pandas as pd
 
@@ -37,11 +38,11 @@ class Base:
     size = 20
     request_params: dict = {}
 
-    def __init__(self):
+    def __init__(self) -> None:
         """initiate module"""
         self.reset()
 
-    def _set_signal(self, signal):
+    def _set_signal(self, signal: str) -> None:
         """set signal.
 
         Args:
@@ -52,7 +53,7 @@ class Base:
         validate_choice(signal, signal_dict, "signal")
         self.request_params["s"] = signal_dict[signal]
 
-    def _set_filters(self, filters_dict):
+    def _set_filters(self, filters_dict: dict[str, str]) -> None:
         """Set filters.
 
         Args:
@@ -72,7 +73,7 @@ class Base:
         if len(filters) != 0:
             self.request_params["f"] = ",".join(filters)
 
-    def _set_ticker(self, ticker):
+    def _set_ticker(self, ticker: str) -> None:
         """Set ticker.
 
         Args:
@@ -82,7 +83,12 @@ class Base:
             return
         self.request_params["t"] = ticker
 
-    def set_filter(self, signal="", filters_dict=None, ticker=""):
+    def set_filter(
+        self,
+        signal: str = "",
+        filters_dict: dict[str, str] | None = None,
+        ticker: str = "",
+    ) -> None:
         """Update the settings.
 
         Args:
@@ -96,14 +102,21 @@ class Base:
         self._set_ticker(ticker)
         self._set_filters(filters_dict)
 
-    def _get_page(self, soup):
+    def _get_page(self, soup: Any) -> int:
         """Check the page number"""
         select = soup.find(id="pageSelect")
         if select is None:
             return 0
         return len(select.find_all("option"))
 
-    def _get_table(self, rows, df, num_col_index, table_header, limit=-1):
+    def _get_table(
+        self,
+        rows: Any,
+        df: pd.DataFrame,
+        num_col_index: list[int],
+        table_header: list[str],
+        limit: int = -1,
+    ) -> pd.DataFrame:
         """Get screener table helper function.
 
         Returns:
@@ -142,7 +155,7 @@ class Base:
             return new_df
         return pd.concat([df, new_df], ignore_index=True)
 
-    def _screener_table(self, soup):
+    def _screener_table(self, soup: Any) -> Any:
         """Locate the screener results table, or raise on a Structural break."""
         return require(
             soup.find("table", class_="screener_table"),
@@ -150,13 +163,15 @@ class Base:
             "table.screener_table",
         )
 
-    def _parse_table_header(self, soup):
+    def _parse_table_header(self, soup: Any) -> list[str]:
         table = self._screener_table(soup)
         rows = table.findAll("tr")
         table_headers = [i.text.strip() for i in rows[0].findAll("th")][1:]
         return table_headers
 
-    def _parse_table(self, df, soup, limit):
+    def _parse_table(
+        self, df: pd.DataFrame | None, soup: Any, limit: int
+    ) -> pd.DataFrame:
         if df is None:
             table_headers = self._parse_table_header(soup)
             df = pd.DataFrame([], columns=table_headers)
@@ -169,22 +184,22 @@ class Base:
         df = self._get_table(rows, df, num_col_index, table_headers, limit)
         return df
 
-    def _parse_columns(self, columns):
+    def _parse_columns(self, columns: list | None) -> None:
         return
 
-    def reset(self):
+    def reset(self) -> None:
         self.request_params = {"v": self.v_page}
 
     def screener_view(
         self,
-        order="Ticker",
-        limit=100000,
-        select_page=None,
-        verbose=1,
-        ascend=True,
-        columns=None,
-        sleep_sec=1,
-    ):
+        order: str = "Ticker",
+        limit: int = 100000,
+        select_page: int | None = None,
+        verbose: int = 1,
+        ascend: bool = True,
+        columns: list | None = None,
+        sleep_sec: int = 1,
+    ) -> pd.DataFrame:
         """Get screener table.
 
         Args:
@@ -234,7 +249,13 @@ class Base:
         self.reset()
         return df
 
-    def compare(self, ticker, compare_list, order="ticker", verbose=1):
+    def compare(
+        self,
+        ticker: str,
+        compare_list: list[str],
+        order: str = "ticker",
+        verbose: int = 1,
+    ) -> pd.DataFrame:
         """Get screener table of similar property (Sector, Industry, Country)
 
         Args:

--- a/finvizfinance/screener/custom.py
+++ b/finvizfinance/screener/custom.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import pandas as pd
+
 from finvizfinance.screener.base import Base
 
 
@@ -17,7 +19,7 @@ class Custom(Base):
 
     v_page = 151
 
-    def _parse_columns(self, columns):
+    def _parse_columns(self, columns: list | None) -> None:
         if not columns:
             return
         if 0 in columns:
@@ -28,14 +30,14 @@ class Custom(Base):
 
     def screener_view(
         self,
-        order="Ticker",
-        limit=-1,
-        select_page=None,
-        verbose=1,
-        ascend=True,
-        columns=None,
-        sleep_sec=1,
-    ):
+        order: str = "Ticker",
+        limit: int = -1,
+        select_page: int | None = None,
+        verbose: int = 1,
+        ascend: bool = True,
+        columns: list | None = None,
+        sleep_sec: int = 1,
+    ) -> pd.DataFrame:
         """Get screener table.
 
         Args:

--- a/finvizfinance/screener/ticker.py
+++ b/finvizfinance/screener/ticker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from time import sleep
+from typing import Any
 
 from finvizfinance.constants import order_dict
 from finvizfinance.screener.base import Base
@@ -29,7 +30,9 @@ class Ticker(Base):
 
     v_page = 411
 
-    def _screener_helper(self, i, page, soup, tickers, limit):
+    def _screener_helper(
+        self, i: int, page: int, soup: Any, tickers: list[str], limit: int
+    ) -> list[str]:
         td = require(
             soup.find("td", class_="screener-tickers"),
             self.url,
@@ -45,9 +48,14 @@ class Ticker(Base):
             tickers.append(parts[1] if len(parts) > 1 else parts[0])
         return tickers
 
-    def screener_view(
-        self, order="Ticker", limit=-1, verbose=1, ascend=True, sleep_sec=1
-    ):
+    def screener_view(  # type: ignore[override]  # public API intentionally differs from Base
+        self,
+        order: str = "Ticker",
+        limit: int = -1,
+        verbose: int = 1,
+        ascend: bool = True,
+        sleep_sec: int = 1,
+    ) -> list[str] | None:
         """Get screener stocks.
 
         Args:
@@ -73,7 +81,7 @@ class Ticker(Base):
         if verbose == 1:
             progress_bar(1, page)
 
-        tickers = []
+        tickers: list[str] = []
         tickers = self._screener_helper(0, page, soup, tickers, limit)
 
         for i in range(1, page):

--- a/finvizfinance/screener/util.py
+++ b/finvizfinance/screener/util.py
@@ -9,7 +9,7 @@ from finvizfinance.constants import (
 from finvizfinance.util import validate_choice
 
 
-def get_signal():
+def get_signal() -> list[str]:
     """Get signals.
 
     Returns:
@@ -18,7 +18,7 @@ def get_signal():
     return list(signal_dict.keys())
 
 
-def get_filters():
+def get_filters() -> list[str]:
     """Get filters.
 
     Returns:
@@ -27,7 +27,7 @@ def get_filters():
     return list(filter_dict.keys())
 
 
-def get_filter_options(screen_filter):
+def get_filter_options(screen_filter: str) -> list[str]:
     """Get filters options.
 
     Args:
@@ -40,7 +40,7 @@ def get_filter_options(screen_filter):
     return list(filter_dict[screen_filter]["option"])
 
 
-def get_orders():
+def get_orders() -> list[str]:
     """Get orders.
 
     Returns:
@@ -49,7 +49,7 @@ def get_orders():
     return list(order_dict.keys())
 
 
-def get_custom_screener_columns():
+def get_custom_screener_columns() -> dict[int, str]:
     """Get information about the columns
 
     Returns:

--- a/finvizfinance/util.py
+++ b/finvizfinance/util.py
@@ -103,7 +103,7 @@ def _retry_after(response: Any, attempt: int) -> float:
     header = response.headers.get("Retry-After") if response is not None else None
     if header and header.replace(".", "", 1).isdigit():
         return min(float(header), BACKOFF_CAP)
-    return min(BACKOFF_BASE * (2**attempt), BACKOFF_CAP)
+    return float(min(BACKOFF_BASE * (2**attempt), BACKOFF_CAP))
 
 
 def _request(url: str, params: dict | None = None, stream: bool = False) -> Any:
@@ -408,7 +408,7 @@ def image_scrap_function(
         name = website.split("?")[1].split("&")[0].split(".")[0]
         chart_name = name.split("_")[0]
         if chart.lower() == chart_name:
-            charturl = "https://finviz.com/" + website
+            charturl: str = "https://finviz.com/" + website
             if not urlonly:
                 image_scrap(charturl, name, "")
             return charturl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,4 +87,17 @@ ignore = ["E501"]
 python_version = "3.10"
 ignore_missing_imports = true
 disable_error_code = ["import-untyped"]
-files = ["finvizfinance"]
+files = ["finvizfinance", "scripts"]
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+# beautifulsoup4's published type stubs (4.13+) are strict about attribute
+# access (``str | AttributeValueList | None``) and ResultSet element types,
+# which is noise for a scraper that treats parsed nodes dynamically. Treat bs4
+# as untyped so the ratchet covers our own logic rather than bs4's shape, and
+# so results do not depend on the installed bs4/mypy version.
+[[tool.mypy.overrides]]
+module = ["bs4", "bs4.*"]
+follow_imports = "skip"

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -19,6 +19,7 @@ Usage::
 
 import os
 import sys
+from collections.abc import Callable
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -28,45 +29,45 @@ from finvizfinance.exceptions import (  # noqa: E402
 )
 
 
-def _checks():
+def _checks() -> list[tuple[str, Callable[[], None]]]:
     """Named callables that each perform one representative live scrape."""
 
-    def quote_fundament():
+    def quote_fundament() -> None:
         from finvizfinance.quote import finvizfinance
 
         finvizfinance("AAPL").ticker_fundament()
 
-    def calendar():
+    def calendar() -> None:
         from finvizfinance.calendar import Calendar
 
         Calendar().calendar()
 
-    def insider():
+    def insider() -> None:
         from finvizfinance.insider import Insider
 
         Insider().get_insider()
 
-    def news():
+    def news() -> None:
         from finvizfinance.news import News
 
         News().get_news()
 
-    def screener():
+    def screener() -> None:
         from finvizfinance.screener.overview import Overview
 
         Overview().screener_view(limit=20, verbose=0)
 
-    def group():
+    def group() -> None:
         from finvizfinance.group.overview import Overview
 
         Overview().screener_view(group="Sector")
 
-    def crypto():
+    def crypto() -> None:
         from finvizfinance.crypto import Crypto
 
         Crypto().performance()
 
-    def futures():
+    def futures() -> None:
         from finvizfinance.future import Future
 
         Future().performance()
@@ -83,7 +84,7 @@ def _checks():
     ]
 
 
-def main():
+def main() -> int:
     drift = []
     errors = []
     blocked = []

--- a/scripts/refresh_fixtures.py
+++ b/scripts/refresh_fixtures.py
@@ -42,7 +42,7 @@ TARGETS = {
 }
 
 
-def main():
+def main() -> None:
     os.makedirs(LIVE_DIR, exist_ok=True)
     blocked = 0
     for name, url in TARGETS.items():


### PR DESCRIPTION
Makes the internals honor the shipped `py.typed` promise by ratcheting mypy from lax to moderate (not strict). No behavior change; public API frozen.

## Config (`pyproject.toml` `[tool.mypy]`)
Added `disallow_untyped_defs`, `warn_return_any`, `warn_unused_ignores`, `warn_redundant_casts`; extended `files` to `["finvizfinance", "scripts"]`. Did **not** set `strict = true`.

## Fixing the 85 resulting errors
- **Annotations** on every flagged function/method across `finvizfinance/` (calendar, earnings, exceptions, future, insider, news, quote, util, and the screener/group modules) and `scripts/` (live_smoke, refresh_fixtures). BeautifulSoup nodes / pandas cells are `Any` (matching the existing `util.py` style); DataFrame-returning parsers are `-> pd.DataFrame`.
- **`constants.py`**: typed the two parent dicts (`util_dict`, `group_util_dict`) as `dict[str, Any]` so the derived `signal/filter/order/group` dicts type-check at their use sites (they were inferred as `object`). This surfaced only because ratcheting turns on body-checking of the now-annotated functions. No data or structure change — `constants.py` is not split.
- **2 `no-any-return`**: coerced `Quote.get_current`/`ticker_description` bs4 `.text` and `util._retry_after`'s `2**attempt`-derived value to their declared `str`/`float` (behavior-identical).
- **`Earnings.partition_days`**: `assert fearnings is not None` (a non-financial mode is always set above; can't fire) so mypy sees the screener is non-None.
- **Intentional LSP overrides**: `Ticker.screener_view` and `Spectrum.screener_view` genuinely diverge from their base signatures (frozen public API), so each carries a targeted `# type: ignore[override]` with a comment — rather than changing the signatures.

## Validation
`mypy` → **Success: no issues found in 33 source files** (finvizfinance/ + scripts/); `ruff check` + `ruff format --check` clean; `pytest test` → **99 passed**.
