### PR TITLE
test: cover resilience core + untested views; gate the coverage floor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,11 @@ jobs:
       - name: Run coverage
         run: |
           coverage run -m pytest test
-          coverage report -m
           coverage lcov -o coverage.lcov
+          coverage report -m
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v2
+        if: always()
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,13 @@ warn_redundant_casts = true
 [[tool.mypy.overrides]]
 module = ["bs4", "bs4.*"]
 follow_imports = "skip"
+
+[tool.coverage.run]
+source = ["finvizfinance"]
+
+[tool.coverage.report]
+show_missing = true
+# Ratchet-up floor. The measured baseline is ~86.5%; the gate sits just below
+# it so a genuine regression fails CI while cross-interpreter rounding noise
+# does not. Raise this as coverage improves; never lower it.
+fail_under = 86

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -4,8 +4,12 @@ import pytest
 from conftest import FakeResponse, blocked_response, html_response, use_session
 
 from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
+from finvizfinance.group.custom import Custom
 from finvizfinance.group.overview import Overview
+from finvizfinance.group.performance import Performance
 from finvizfinance.group.spectrum import Spectrum
+from finvizfinance.group.util import get_group, get_orders
+from finvizfinance.group.valuation import Valuation
 
 
 def test_group_overview_real():
@@ -77,3 +81,30 @@ def test_group_spectrum_wall_raises_blocked_error():
     use_session(blocked_response())
     with pytest.raises(FinvizBlockedError):
         Spectrum().screener_view(group="Sector", order="Name")
+
+
+@pytest.mark.parametrize("view_cls", [Overview, Valuation, Performance, Custom])
+def test_group_views_parse_groups_table(view_cls):
+    # Each group view inherits the shared groups_table parse; exercise them all.
+    use_session(html_response("groups_table.html"))
+    df = view_cls().screener_view(group="Industry")
+    assert list(df["Name"]) == ["Bitcoin", "Ethereum"]
+
+
+def test_group_custom_parse_columns_sets_c_param():
+    view = Custom()
+    view._parse_columns([1, 2, 3])
+    assert view.request_params["c"] == "1,2,3"
+
+
+def test_group_custom_parse_columns_empty_is_noop():
+    view = Custom()
+    view._parse_columns([])
+    assert "c" not in view.request_params
+
+
+def test_group_util_helpers():
+    groups = get_group()
+    orders = get_orders()
+    assert isinstance(groups, list) and "Sector" in groups
+    assert isinstance(orders, list) and len(orders) > 0

--- a/test/test_screener.py
+++ b/test/test_screener.py
@@ -6,8 +6,14 @@ from conftest import blocked_response, html_response, use_session
 from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 from finvizfinance.screener import get_filter_options, get_filters, get_signal
 from finvizfinance.screener.custom import Custom
+from finvizfinance.screener.financial import Financial
 from finvizfinance.screener.overview import Overview
+from finvizfinance.screener.ownership import Ownership
+from finvizfinance.screener.performance import Performance
+from finvizfinance.screener.technical import Technical
 from finvizfinance.screener.ticker import Ticker
+from finvizfinance.screener.util import get_custom_screener_columns, get_orders
+from finvizfinance.screener.valuation import Valuation
 
 
 def test_screener_overview_real():
@@ -109,3 +115,37 @@ def test_screener_get_settings():
     assert isinstance(get_filter_options("Exchange"), list)
     with pytest.raises(ValueError):
         get_filter_options("Dummy")
+
+
+@pytest.mark.parametrize(
+    "view_cls", [Financial, Ownership, Performance, Technical, Valuation]
+)
+def test_screener_views_parse_table(view_cls):
+    # Each screener view inherits Base.screener_view; exercise them all.
+    use_session(html_response("screener_overview.html"))
+    df = view_cls().screener_view(verbose=0)
+    assert list(df["Ticker"]) == ["AAPL", "MSFT"]
+
+
+def test_screener_custom_parse_columns_prepends_zero():
+    view = Custom()
+    view._parse_columns([2, 1])
+    assert view.request_params["c"] == "0,2,1"
+
+
+def test_screener_custom_parse_columns_dedupes_leading_zero():
+    view = Custom()
+    view._parse_columns([0, 5])
+    assert view.request_params["c"] == "0,5"
+
+
+def test_screener_custom_parse_columns_empty_is_noop():
+    view = Custom()
+    view._parse_columns([])
+    assert "c" not in view.request_params
+
+
+def test_screener_util_get_orders_and_columns():
+    assert isinstance(get_orders(), list) and len(get_orders()) > 0
+    columns = get_custom_screener_columns()
+    assert isinstance(columns, dict) and len(columns) > 0

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -173,3 +173,75 @@ def test_number_covert_is_deprecated_alias():
         warnings.simplefilter("always")
         assert number_covert("3M") == 3000000
     assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+# --- resilience core: Wall detection + backoff ------------------------------
+
+
+def test_is_wall_true_on_cf_mitigated_challenge():
+    resp = FakeResponse(status_code=403, headers={"cf-mitigated": "challenge"})
+    assert util._is_wall(resp) is True
+
+
+def test_is_wall_true_on_body_markers():
+    for marker in ("...Just a moment...", "cf-chl_abc", "challenge-platform"):
+        assert util._is_wall(FakeResponse(text=marker, status_code=403)) is True
+
+
+def test_is_wall_false_on_ok_plain_403_and_5xx():
+    assert util._is_wall(FakeResponse(text="ok", status_code=200)) is False
+    # a 403 with no challenge markers is a real error, not a Wall
+    assert util._is_wall(FakeResponse(text="denied", status_code=403)) is False
+    # 500 is not a Wall status at all (it is a transient-retry status instead)
+    assert util._is_wall(FakeResponse(text="boom", status_code=500)) is False
+
+
+def test_retry_after_honors_numeric_header():
+    resp = FakeResponse(status_code=503, headers={"Retry-After": "2"})
+    assert util._retry_after(resp, attempt=0) == 2.0
+
+
+def test_retry_after_caps_large_header():
+    resp = FakeResponse(status_code=503, headers={"Retry-After": "999"})
+    assert util._retry_after(resp, attempt=0) == util.BACKOFF_CAP
+
+
+def test_retry_after_exponential_backoff_when_no_usable_header():
+    # None response and a non-numeric header both fall back to capped backoff.
+    assert util._retry_after(None, attempt=0) == min(
+        util.BACKOFF_BASE * (2**0), util.BACKOFF_CAP
+    )
+    resp = FakeResponse(status_code=503, headers={"Retry-After": "soon"})
+    assert util._retry_after(resp, attempt=2) == min(
+        util.BACKOFF_BASE * (2**2), util.BACKOFF_CAP
+    )
+    assert util._retry_after(None, attempt=99) == util.BACKOFF_CAP
+
+
+def test_retry_after_header_path_retries_then_succeeds():
+    fake = use_session(
+        [
+            FakeResponse(status_code=503, headers={"Retry-After": "1"}),
+            FakeResponse(text="<html>ok</html>"),
+        ]
+    )
+    soup = web_scrap("https://finviz.com/x")
+    assert "ok" in soup.text
+    assert len(fake.calls) == 2
+
+
+def test_wall_detected_by_body_marker_without_header():
+    fake = use_session(
+        FakeResponse(text="<html>Just a moment...</html>", status_code=403)
+    )
+    with pytest.raises(FinvizBlockedError):
+        web_scrap("https://finviz.com/x")
+    assert len(fake.calls) == util.MAX_RETRIES + 1
+
+
+def test_non_retry_http_error_is_reraised_without_retry():
+    # A 404 is neither transient nor a Wall: surfaced as HTTPError, no retry.
+    fake = use_session(FakeResponse(status_code=404))
+    with pytest.raises(requests.exceptions.HTTPError):
+        web_scrap("https://finviz.com/x")
+    assert len(fake.calls) == 1


### PR DESCRIPTION
Tests the resilience core the library's release confidence rests on, and turns coverage from measure-only into an enforced floor. Tests + CI/config only — no source changes.

## Resilience-core tests (were untested)
Direct assertions on the transport added by the reliability overhaul:
- `util._is_wall`: `cf-mitigated: challenge`, body markers (`Just a moment`, `cf-chl`, `challenge-platform`), and negative cases (200, a plain 403, a 500).
- `util._retry_after`: numeric `Retry-After` honored, capped at `BACKOFF_CAP`, and exponential-backoff fallback (non-numeric header / `None` response / cap).
- Integration through the session seam: a `503 + Retry-After` retries then succeeds; a body-marker Wall (no header) exhausts retries → `FinvizBlockedError`; a non-retry `404` surfaces as `HTTPError` with no retry.

## Previously import-only views/helpers now exercised
- group `Overview`/`Valuation`/`Performance`/`Custom` parse `groups_table`; `group.util.get_group`/`get_orders`.
- screener `Financial`/`Ownership`/`Performance`/`Technical`/`Valuation` parse the screener table; `screener.util.get_orders`/`get_custom_screener_columns`.
- both `Custom._parse_columns` (screener prepends/dedupes index 0; group joins; empty is a no-op).
- `constants.py` left untested (pure data).

## Coverage floor gate (was measure-but-don't-gate)
- `[tool.coverage.run] source = ["finvizfinance"]` so local and CI measure the same thing (the package, not test files).
- `[tool.coverage.report] fail_under = 86` — measured baseline is ~86.5%; the floor sits just below so a real regression fails CI while cross-interpreter rounding noise doesn't. Ratchet-up only.
- CI `coverage` job now builds `coverage.lcov` **before** the gating `coverage report -m`, so a regression fails the job; the Coveralls upload runs via `if: always()` (still informational, still `continue-on-error`).

## Validation
`pytest test` → **124 passed** (was 99). Coverage **86.52%**. Verified the gate fires: `coverage report --fail-under=95` exits 2; the configured `fail_under=86` exits 0. `ruff check` + `ruff format --check` + `mypy` all clean.
