### PR TITLE
docs: document Calendar/Earnings/Future; read Sphinx version from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,49 @@ df.head()
 
 Getting list of tickers according to the filters.
 
+### Calendar
+
+Getting the economic calendar (release datetime, impact, actual/expected/prior).
+
+```python
+from finvizfinance.calendar import Calendar
+
+fcalendar = Calendar()
+df = fcalendar.calendar()
+df.head()
+```
+
+### Earnings
+
+Partitioning tickers by their earnings dates for a period.
+
+```python
+from finvizfinance.earnings import Earnings
+
+# period: This Week (default), Next Week, Previous Week, This Month
+fearnings = Earnings(period='This Week')
+
+# mode: financial (default), overview, valuation, ownership, performance, technical
+days = fearnings.partition_days(mode='financial')
+
+# optionally export the partitioned tables
+fearnings.output_excel('earning_days.xlsx')
+fearnings.output_csv('earning_days')
+```
+
+### Future
+
+Getting futures performance.
+
+```python
+from finvizfinance.future import Future
+
+ffuture = Future()
+# timeframe: D (default), W, M, Q, HY, Y
+df = ffuture.performance(timeframe='D')
+df.head()
+```
+
 ### Misc (Proxy)
 
 Optional proxy can be used for getting information from FinViz website. Accessible from finvizfinance

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,11 +11,14 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../../"))
 
+import finvizfinance  # noqa: E402  (import after sys.path is configured above)
+
 project = "finvizfinance"
 copyright = "2024, Tianning Li"
 author = "Tianning Li"
-# The full version, including alpha/beta/rc tags
-release = "1.4.0"
+# Read the version from the package so the docs never drift from __version__.
+version = finvizfinance.__version__
+release = finvizfinance.__version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/finvizfinance/earnings.py
+++ b/finvizfinance/earnings.py
@@ -73,8 +73,8 @@ class Earnings:
         """Partition dataframe to separate dataframes according to the dates.
 
         Args:
-            mode(str): choose an option of period(financial, overview, valuation, ownership,
-                       performance, technical).
+            mode(str): choose an option of mode (financial, overview, valuation,
+                       ownership, performance, technical).
         """
         check_list = [
             "financial",

--- a/finvizfinance/group/spectrum.py
+++ b/finvizfinance/group/spectrum.py
@@ -24,7 +24,7 @@ class Spectrum(Base):
     def screener_view(  # type: ignore[override]  # public API intentionally differs from Base
         self, group: str = "Sector", order: str = "Name", out_dir: str = ""
     ) -> None:
-        """Get screener table.
+        """Download the group spectrum image.
 
         Args:
             group(str): choice of group option.


### PR DESCRIPTION
Targeted docs pass — no repo-wide docstring sweep, no behavior change.

## Changes
- **README**: add usage sections for **Calendar**, **Earnings**, and **Future** — public modules that had no README presence. Each mirrors the existing section style (short intro + runnable snippet) and documents the real API (`Calendar().calendar()`; `Earnings(period=...).partition_days(mode=...)` + `output_excel`/`output_csv`; `Future().performance(timeframe=...)`).
- **Sphinx version drift**: `docs/source/conf.py` hardcoded `release = "1.4.0"`. Now `version`/`release` are read from `finvizfinance.__version__` (the repo root is already on `sys.path`), so docs can never drift from the package.
- **Docstrings** (only on code touched by earlier campaign PRs, per scope):
  - `Earnings.partition_days`: Args said "choose an option of **period**" → corrected to **mode**.
  - `Spectrum.screener_view`: summary was "Get screener table" → "Download the group spectrum image" (it saves an image, not a table).

`release.md` left as-is; `constants.py` untouched.

## Validation
- **Sphinx build succeeds** locally (`sphinx -b html`, rc 0); the built HTML shows the dynamic **1.4.0** in the version display on every page. (Only warning is the pre-existing missing `_static` dir, unrelated.)
- `conf.py` executed as Sphinx loads it → `release == finvizfinance.__version__`.
- `pytest test` → **124 passed**; `ruff check` + `ruff format --check` + `mypy` clean; coverage gate unaffected.
