### PR TITLE
fix: parse economic calendar from route-init-data JSON

### DIFF
--- a/finvizfinance/calendar.py
+++ b/finvizfinance/calendar.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Any
 
 import pandas as pd
@@ -43,16 +44,108 @@ class Calendar:
     def calendar(self) -> pd.DataFrame:
         """Get economic calendar table."""
         soup = web_scrap(CALENDAR_URL)
+
+        # Current shape: the page is a client-rendered app and the calendar rows
+        # ship as JSON inside <script id="route-init-data" type="application/json">.
+        entries = self._route_init_entries(soup)
+        if entries is not None:
+            return self._entries_dataframe(entries)
+
+        # Legacy shape 1: a server-rendered <table class="calendar">.
         tables = soup.find_all("table", class_="calendar")
         if tables:
             return self._calendar_tables(tables)
 
+        # Legacy shape 2: client hydration via FinvizInitCalendar([...]).
         data = _script_json(soup, "FinvizInitCalendar")
-        if data is None:
+        if data is not None:
+            return self._init_dataframe(data)
+
+        raise FinvizParseError(
+            url=CALENDAR_URL,
+            selector="script#route-init-data, table.calendar, or FinvizInitCalendar",
+        )
+
+    # -- current: route-init-data JSON ------------------------------------------
+
+    @staticmethod
+    def _route_init_entries(soup: Any) -> list[Any] | None:
+        """Return the calendar entries embedded in the ``route-init-data`` script.
+
+        Returns ``None`` when the script is absent, so the caller can fall back
+        to the legacy page shapes. A script that *is* present but whose payload
+        no longer exposes ``data.entries`` is finviz Drift and raises.
+        """
+        tag = soup.find("script", id="route-init-data")
+        if tag is None:
+            return None
+        raw = tag.string or tag.get_text() or ""
+        if not raw.strip():
+            return None
+        payload = decode_json_after(raw, 0, CALENDAR_URL, "route-init-data JSON")
+        data = payload.get("data") if isinstance(payload, dict) else None
+        entries = data.get("entries") if isinstance(data, dict) else None
+        if not isinstance(entries, list):
             raise FinvizParseError(
-                url=CALENDAR_URL, selector="table.calendar or FinvizInitCalendar"
+                url=CALENDAR_URL, selector="route-init-data data.entries"
             )
-        rows = [self._calendar_row(row) for row in data if isinstance(row, dict)]
+        return entries
+
+    @classmethod
+    def _entries_dataframe(cls, entries: list[Any]) -> pd.DataFrame:
+        rows = [cls._entry_row(row) for row in entries if isinstance(row, dict)]
+        # A non-empty payload that yields no readable values means finviz renamed
+        # the JSON fields (Drift). Surface it instead of returning an all-None
+        # table that would silently pass the live smoke check.
+        if entries and not any(
+            value is not None for row in rows for value in row.values()
+        ):
+            raise FinvizParseError(
+                url=CALENDAR_URL, selector="route-init-data entry fields"
+            )
+        return pd.DataFrame(rows)
+
+    @classmethod
+    def _entry_row(cls, entry: dict[str, Any]) -> dict[str, Any]:
+        """Normalize a route-init-data calendar entry to the public columns."""
+
+        def value(*keys: str) -> Any:
+            for key in keys:
+                if entry.get(key) is not None:
+                    return entry[key]
+            return None
+
+        importance = value("importance", "impact")
+        return {
+            "Datetime": cls._format_datetime(entry),
+            "Release": value("event", "release", "title"),
+            "Impact": str(importance) if importance is not None else None,
+            "For": value("reference", "for", "period"),
+            "Actual": value("actual"),
+            "Expected": value("forecast", "expected", "estimate"),
+            "Prior": value("previous", "prior"),
+        }
+
+    @staticmethod
+    def _format_datetime(entry: dict[str, Any]) -> Any:
+        """Render the ISO ``date`` field as the historic "Day, Time" string."""
+        raw = entry.get("date") or entry.get("datetime")
+        if not raw:
+            return None
+        try:
+            moment = datetime.fromisoformat(str(raw))
+        except ValueError:
+            # Unrecognized date format: return it verbatim rather than drop it.
+            return raw
+        if entry.get("allDay"):
+            return moment.strftime("%a %b %d")
+        return moment.strftime("%a %b %d, %I:%M %p")
+
+    # -- legacy: FinvizInitCalendar([...]) --------------------------------------
+
+    @classmethod
+    def _init_dataframe(cls, data: list[Any]) -> pd.DataFrame:
+        rows = [cls._calendar_row(row) for row in data if isinstance(row, dict)]
         # A non-empty payload that yields no readable values means finviz
         # renamed the JSON fields (Drift). Surface it instead of returning an
         # all-None table that would silently pass the live smoke check.
@@ -87,6 +180,8 @@ class Calendar:
             "Expected": value("expected", "estimate"),
             "Prior": value("prior", "previous"),
         }
+
+    # -- legacy: server-rendered <table class="calendar"> -----------------------
 
     @staticmethod
     def _calendar_tables(tables: Any) -> pd.DataFrame:

--- a/test/fixtures/calendar_route_init.html
+++ b/test/fixtures/calendar_route_init.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head><title>Economic Calendar</title></head>
+<body>
+<!--
+  Trimmed capture of the live calendar.ashx page (2026-08-29). The page is a
+  client-rendered app: the economic-calendar rows are shipped as JSON inside a
+  <script id="route-init-data" type="application/json"> element rather than a
+  server-rendered table. Only three representative entries are kept here.
+-->
+<div id="root"></div>
+<script id="route-init-data" type="application/json">{"data":{"initialDateFrom":"2026-08-24","entries":[{"calendarId":399129,"ticker":"USACPPIM","event":"Core PCE Price Index MoM","category":"Core PCE Price Index MoM","date":"2026-08-26T08:30:00","reference":"Jul","referenceDate":"2026-07-31","actual":"0.2%","previous":"0.1%","forecast":"0.2%","teforecast":"0.3%","importance":3,"isHigherPositive":-1,"hasNoDetail":false,"alert":null,"allDay":false,"nonEmptinessScore":3},{"calendarId":398572,"ticker":"UNITEDSTACHIFEDNATAC","event":"Chicago Fed National Activity Index","category":"Chicago Fed National Activity Index","date":"2026-08-24T08:30:00","reference":"Jul","referenceDate":"2026-07-31","actual":"-0.08","previous":"0.06","forecast":null,"teforecast":"0.1","importance":2,"isHigherPositive":1,"hasNoDetail":false,"alert":null,"allDay":false,"nonEmptinessScore":2},{"calendarId":396607,"ticker":"UNITEDSTA3MONBILYIE","event":"3-Month Bill Auction","category":"3 Month Bill Yield","date":"2026-08-24T11:30:00","reference":null,"referenceDate":null,"actual":"3.715%","previous":"3.715%","forecast":null,"teforecast":null,"importance":1,"isHigherPositive":-1,"hasNoDetail":false,"alert":null,"allDay":false,"nonEmptinessScore":1}]},"version":3}</script>
+</body>
+</html>

--- a/test/fixtures/calendar_route_init_empty.html
+++ b/test/fixtures/calendar_route_init_empty.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Economic Calendar</title></head>
+<body>
+<!-- A quiet calendar day: route-init-data is present but carries no entries. -->
+<div id="root"></div>
+<script id="route-init-data" type="application/json">{"data":{"initialDateFrom":"2026-08-24","entries":[]},"version":3}</script>
+</body>
+</html>

--- a/test/fixtures/calendar_route_init_no_entries.html
+++ b/test/fixtures/calendar_route_init_no_entries.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><title>Economic Calendar</title></head>
+<body>
+<!--
+  finviz keeps a route-init-data script but the calendar payload no longer
+  exposes data.entries (shape moved) -> Drift.
+-->
+<div id="root"></div>
+<script id="route-init-data" type="application/json">{"data":{"initialDateFrom":"2026-08-24","rows":[]},"version":3}</script>
+</body>
+</html>

--- a/test/fixtures/calendar_route_init_unknown_keys.html
+++ b/test/fixtures/calendar_route_init_unknown_keys.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><title>Economic Calendar</title></head>
+<body>
+<!--
+  finviz keeps the route-init-data script and its entries array, but renames
+  every field. The normalized rows are all-None -> Drift, not data.
+-->
+<div id="root"></div>
+<script id="route-init-data" type="application/json">{"data":{"initialDateFrom":"2026-08-24","entries":[{"foo":"2026-08-26T08:30:00","bar":"GDP Growth Rate","baz":3}]},"version":3}</script>
+</body>
+</html>

--- a/test/test_calendar.py
+++ b/test/test_calendar.py
@@ -1,10 +1,27 @@
 """Offline fixture tests for the calendar scraper (see test_quote for the pattern)."""
 
+from typing import Any
+
+import pandas as pd
 import pytest
 from conftest import blocked_response, html_response, use_session
 
 from finvizfinance.calendar import Calendar
 from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
+
+
+def _records(frame: pd.DataFrame) -> list[dict[str, Any]]:
+    """``to_dict("records")`` with missing values normalized to ``None``.
+
+    pandas renders a missing object cell as ``nan`` (>=2.1) or ``None`` (older)
+    depending on the version installed, so compare on the normalized form to
+    keep the assertion stable across the CI matrix's unpinned ``pandas>=1.5``.
+    """
+    return [
+        {key: (None if pd.isna(value) else value) for key, value in row.items()}
+        for row in frame.to_dict("records")
+    ]
+
 
 # --- current shape: <script id="route-init-data" type="application/json"> ------
 
@@ -12,7 +29,7 @@ from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 def test_calendar_route_init_data():
     use_session(html_response("calendar_route_init.html"))
     df = Calendar().calendar()
-    assert df.to_dict("records") == [
+    assert _records(df) == [
         {
             "Datetime": "Wed Aug 26, 08:30 AM",
             "Release": "Core PCE Price Index MoM",

--- a/test/test_calendar.py
+++ b/test/test_calendar.py
@@ -6,6 +6,71 @@ from conftest import blocked_response, html_response, use_session
 from finvizfinance.calendar import Calendar
 from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
 
+# --- current shape: <script id="route-init-data" type="application/json"> ------
+
+
+def test_calendar_route_init_data():
+    use_session(html_response("calendar_route_init.html"))
+    df = Calendar().calendar()
+    assert df.to_dict("records") == [
+        {
+            "Datetime": "Wed Aug 26, 08:30 AM",
+            "Release": "Core PCE Price Index MoM",
+            "Impact": "3",
+            "For": "Jul",
+            "Actual": "0.2%",
+            "Expected": "0.2%",
+            "Prior": "0.1%",
+        },
+        {
+            "Datetime": "Mon Aug 24, 08:30 AM",
+            "Release": "Chicago Fed National Activity Index",
+            "Impact": "2",
+            "For": "Jul",
+            "Actual": "-0.08",
+            "Expected": None,
+            "Prior": "0.06",
+        },
+        {
+            "Datetime": "Mon Aug 24, 11:30 AM",
+            "Release": "3-Month Bill Auction",
+            "Impact": "1",
+            "For": None,
+            "Actual": "3.715%",
+            "Expected": None,
+            "Prior": "3.715%",
+        },
+    ]
+
+
+def test_calendar_route_init_empty_returns_empty_frame():
+    # A quiet calendar day (entries: []) is a legitimate empty result, not Drift.
+    use_session(html_response("calendar_route_init_empty.html"))
+    df = Calendar().calendar()
+    assert df.empty
+
+
+def test_calendar_route_init_unknown_keys_raise_parse_error():
+    # finviz keeps the route-init-data entries but renames every field -> the
+    # normalized rows are all-None. That is Drift, not data; it must raise
+    # instead of returning a table of Nones the live smoke check waves through.
+    use_session(html_response("calendar_route_init_unknown_keys.html"))
+    with pytest.raises(FinvizParseError) as exc:
+        Calendar().calendar()
+    assert exc.value.selector == "route-init-data entry fields"
+
+
+def test_calendar_route_init_no_entries_raise_parse_error():
+    # The route-init-data script is present but the payload no longer exposes
+    # data.entries (shape moved) -> Drift.
+    use_session(html_response("calendar_route_init_no_entries.html"))
+    with pytest.raises(FinvizParseError) as exc:
+        Calendar().calendar()
+    assert exc.value.selector == "route-init-data data.entries"
+
+
+# --- legacy shapes: table.calendar and FinvizInitCalendar([...]) ---------------
+
 
 def test_calendar_real():
     use_session(html_response("calendar.html"))
@@ -53,7 +118,10 @@ def test_calendar_drift_raises_parse_error_not_silent_empty():
     use_session(html_response("calendar_drift.html"))
     with pytest.raises(FinvizParseError) as exc:
         Calendar().calendar()
-    assert exc.value.selector == "table.calendar or FinvizInitCalendar"
+    assert (
+        exc.value.selector
+        == "script#route-init-data, table.calendar, or FinvizInitCalendar"
+    )
 
 
 def test_calendar_wall_raises_blocked_error():


### PR DESCRIPTION
## Summary

Fixes the live calendar drift found on 2026-08-29: `finviz.com/calendar.ashx` is now a client-rendered app, so both the server-side `table.calendar` element and the `FinvizInitCalendar([...])` hydration script are gone. `Calendar().calendar()` raised `FinvizParseError` against the live site. The calendar rows now ship as JSON inside `<script id="route-init-data" type="application/json">` at `data.entries`.

## Change

`finvizfinance/calendar.py` gains a primary path (`_route_init_entries` / `_entries_dataframe` / `_entry_row` / `_format_datetime`) that:

- parses the `route-init-data` JSON payload,
- maps entry keys `event` / `date` (ISO 8601) / `importance` (1–3) / `reference` / `actual` / `forecast` / `previous` onto the existing public columns `Release` / `Datetime` / `Impact` / `For` / `Actual` / `Expected` / `Prior`,
- renders `Datetime` in the historic `"Mon Aug 26, 08:30 AM"` form and stringifies `Impact` to preserve the old `"3"` contract.

The two legacy shapes are kept as fallbacks (mirroring `future.py`), and the Wall / Drift / empty distinctions are preserved: a present-but-reshaped payload raises Drift; a quiet calendar day returns an empty frame.

## Tests

- New realistic fixture `test/fixtures/calendar_route_init.html` (trimmed from live markup) plus `_empty`, `_unknown_keys`, and `_no_entries` variants.
- Offline tests in `test/test_calendar.py` for the current shape (parse, empty, renamed-keys Drift, no-entries Drift); updated the drift-selector assertion.

## Verification

- Offline suite (bare `pytest test`, CI-faithful): **128 passed, 13 skipped**.
- `ruff check` + `ruff format --check`: clean.
- Opt-in live `test_live_calendar`: **passes**; `Calendar().calendar()` returns a real 90×7 frame with `Impact` values `['1','2','3']`.
