### PR TITLE
ci: automate PyPI publish + weekly live-smoke; drop Coveralls

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,46 @@
+name: live-smoke
+
+# Scheduled early-warning that finviz's markup has Drifted. Never gates PRs.
+# A Cloudflare Wall (403) from the runner's datacenter IP is EXPECTED and does
+# not fail the job; only a parse failure on a 200 (a Drift) or an unexpected
+# error does — see scripts/live_smoke.py.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  live-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Live smoke
+        id: smoke
+        run: python scripts/live_smoke.py
+      - name: File drift issue
+        if: always() && steps.smoke.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create live-smoke-drift --color FBCA04 \
+            --description "finviz markup drift caught by scheduled live-smoke" --force
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body=$(printf 'Scheduled **live-smoke** failed on a 200 response — a finviz **Drift** (markup change) or an unexpected error. A Cloudflare Wall (403) does NOT trigger this.\n\nRun: %s\n\nInspect the failing check(s) in the run log, update the affected parser + fixture, then close this issue.' "$run_url")
+          existing=$(gh issue list --state open --label live-smoke-drift --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "Live-smoke: finviz Drift detected" \
+              --label live-smoke-drift --body "$body"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+# Publish to PyPI via Trusted Publishing (OIDC) — no stored API token.
+# The GitHub Release is the human "ship it" gate; a manual dispatch is kept
+# for re-runs. Requires a one-time PyPI pending-publisher registration:
+#   publisher: GitHub Actions | owner: lit26 | repo: finvizfinance
+#   workflow: publish.yml | environment: pypi
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+      - name: Check metadata
+        run: twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,7 @@ jobs:
       - name: Run coverage
         run: |
           coverage run -m pytest test
-          coverage lcov -o coverage.lcov
           coverage report -m
-      - name: Upload to Coveralls
-        uses: coverallsapp/github-action@v2
-        if: always()
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage.lcov
 
   types:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ![PyPI](https://img.shields.io/pypi/v/finvizfinance)
 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/finvizfinance)
 ![PyPI - License](https://img.shields.io/pypi/l/finvizfinance?color=gre)
-[![Coverage Status](https://coveralls.io/repos/github/lit26/finvizfinance/badge.svg)](https://coveralls.io/github/lit26/finvizfinance)
 ![Read the Docs](https://img.shields.io/readthedocs/finvizfinance)
 [![Downloads](https://pepy.tech/badge/finvizfinance)](https://pepy.tech/project/finvizfinance)
 [![CodeFactor](https://www.codefactor.io/repository/github/lit26/finvizfinance/badge/master)](https://www.codefactor.io/repository/github/lit26/finvizfinance/overview/master)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ docs = [
 dev = [
     "finvizfinance[test,docs]",
     "coverage>=7.5",
-    "coveralls>=4.0",
     "ruff>=0.6",
     "pre-commit>=3.5",
     "mypy>=1.8",


### PR DESCRIPTION
## What & why

Finishes the one unshipped piece of the 2026-08 improvement campaign (PR⑥ release automation) and clears the two open housekeeping items. No package code changes; public API untouched; still 1.x.

### Release automation — `publish.yml`
- Builds sdist + wheel and publishes to PyPI via **Trusted Publishing (OIDC)** — no stored API token.
- Triggers on **GitHub Release published** (the human "ship it" gate) plus manual `workflow_dispatch`.
- Split `build` → `publish` jobs; `publish` runs in a `pypi` environment with `id-token: write` only.

### Drift early-warning — `live-smoke.yml`
- Runs the existing `scripts/live_smoke.py` **weekly** (Mon 06:00 UTC) + `workflow_dispatch`.
- **Non-gating**: a Cloudflare Wall (403) from the runner IP is expected and passes; only a **Drift** (parse-fail on a 200) or unexpected error fails the job.
- On failure it auto-files/updates a deduplicated `live-smoke-drift` issue so drift surfaces without watching the Actions tab.

### Drop Coveralls
- Removed the upload step from `test.yml`, the README badge, and the unused `coveralls` dev dep.
- The local `coverage report` **`fail_under = 86`** gate already enforces the floor, so coverage stays gated.
- This ends the persistent failing legacy `coverage/coveralls (push)` status and moots the old Coveralls token still in git history.

## Verification
- Offline suite: `128 passed, 13 skipped`.
- `coverage report` → TOTAL 87%, exit 0 (gate holds without Coveralls).
- `ruff check` + `ruff format --check` clean; both new workflow YAMLs parse.
- Issue **#156** fix confirmed against live finviz: `finvizfinance("AAPL").ticker_fundament()` returned **90 fields** (was 16). Will close #156 separately.

## Maintainer actions required (console-only, not blocking merge)
1. **PyPI pending publisher** (before the next Release triggers a publish): PyPI → project `finvizfinance` → Publishing → add a GitHub Actions publisher: owner `lit26`, repo `finvizfinance`, workflow `publish.yml`, environment `pypi`. Create a GitHub Environment named `pypi` (optionally with required reviewers).
2. **Coveralls**: remove/disable the `finvizfinance` repo in coveralls.io and invalidate the old repo token (now unused).
3. **CircleCI**: if the retired project still shows, disable it in the CircleCI console.

## Activation note
Scheduled and Release-triggered workflows only run from the **default branch**. After this merges to `develop`, merge `develop → master` so `live-smoke` and `publish` become active. No version bump — nothing in the shipped package changes.
