### PR TITLE
ci: activate publish + live-smoke workflows on master

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,46 @@
+name: live-smoke
+
+# Scheduled early-warning that finviz's markup has Drifted. Never gates PRs.
+# A Cloudflare Wall (403) from the runner's datacenter IP is EXPECTED and does
+# not fail the job; only a parse failure on a 200 (a Drift) or an unexpected
+# error does — see scripts/live_smoke.py.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  live-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Live smoke
+        id: smoke
+        run: python scripts/live_smoke.py
+      - name: File drift issue
+        if: always() && steps.smoke.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create live-smoke-drift --color FBCA04 \
+            --description "finviz markup drift caught by scheduled live-smoke" --force
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body=$(printf 'Scheduled **live-smoke** failed on a 200 response — a finviz **Drift** (markup change) or an unexpected error. A Cloudflare Wall (403) does NOT trigger this.\n\nRun: %s\n\nInspect the failing check(s) in the run log, update the affected parser + fixture, then close this issue.' "$run_url")
+          existing=$(gh issue list --state open --label live-smoke-drift --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "Live-smoke: finviz Drift detected" \
+              --label live-smoke-drift --body "$body"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+# Publish to PyPI via Trusted Publishing (OIDC) — no stored API token.
+# The GitHub Release is the human "ship it" gate; a manual dispatch is kept
+# for re-runs. Requires a one-time PyPI pending-publisher registration:
+#   publisher: GitHub Actions | owner: lit26 | repo: finvizfinance
+#   workflow: publish.yml | environment: pypi
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+      - name: Check metadata
+        run: twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,7 @@ jobs:
       - name: Run coverage
         run: |
           coverage run -m pytest test
-          coverage lcov -o coverage.lcov
           coverage report -m
-      - name: Upload to Coveralls
-        uses: coverallsapp/github-action@v2
-        if: always()
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage.lcov
 
   types:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ![PyPI](https://img.shields.io/pypi/v/finvizfinance)
 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/finvizfinance)
 ![PyPI - License](https://img.shields.io/pypi/l/finvizfinance?color=gre)
-[![Coverage Status](https://coveralls.io/repos/github/lit26/finvizfinance/badge.svg)](https://coveralls.io/github/lit26/finvizfinance)
 ![Read the Docs](https://img.shields.io/readthedocs/finvizfinance)
 [![Downloads](https://pepy.tech/badge/finvizfinance)](https://pepy.tech/project/finvizfinance)
 [![CodeFactor](https://www.codefactor.io/repository/github/lit26/finvizfinance/badge/master)](https://www.codefactor.io/repository/github/lit26/finvizfinance/overview/master)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ docs = [
 dev = [
     "finvizfinance[test,docs]",
     "coverage>=7.5",
-    "coveralls>=4.0",
     "ruff>=0.6",
     "pre-commit>=3.5",
     "mypy>=1.8",


### PR DESCRIPTION
Promote #182 to the default branch so the scheduled **live-smoke** and Release-triggered **publish** workflows become active (both only run from the default branch).

Contents: CI-only changes from #182 — add `publish.yml` (PyPI Trusted Publishing on Release) and `live-smoke.yml` (weekly non-gating drift check), and drop Coveralls in favor of the local `fail_under=86` gate. No package code changes; **no version bump**.

Follow-up (console-only, tracked in #182): register the PyPI pending publisher, disable the coveralls.io repo, and disable the retired CircleCI project.
