### PR TITLE
feat: add screener.from_url to build a screener from a finviz URL (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,28 @@ df.head()
 
 ![insider example](asset/screen_overview.png)
 
+#### Example: From a finviz URL
+
+Instead of translating each criterion into a filters dict by hand, paste the URL
+finviz puts in your address bar as you click filters in its UI. `screener.from_url`
+reads the view (`v`) and reconstructs the filters (`f`), signal (`s`) and ticker
+(`t`), returning the matching screener object:
+
+```python
+from finvizfinance import screener
+
+foverview = screener.from_url(
+    "https://finviz.com/screener.ashx?v=111&f=idx_sp500,sh_avgvol_o500"
+)
+df = foverview.screener_view()
+df.head()
+```
+
+Sort order, pagination and custom columns are `screener_view()` arguments, so
+they are ignored in the URL. Any filter/signal/view code that finvizfinance does
+not recognize raises a `ValueError` naming the code, rather than silently
+dropping it and returning the wrong stocks.
+
 ### Screener (Ticker)
 
 Getting list of tickers according to the filters.

--- a/finvizfinance/screener/__init__.py
+++ b/finvizfinance/screener/__init__.py
@@ -8,6 +8,7 @@ from finvizfinance.screener.performance import Performance
 from finvizfinance.screener.technical import Technical
 from finvizfinance.screener.ticker import Ticker
 from finvizfinance.screener.util import (
+    from_url,
     get_custom_screener_columns,
     get_filter_options,
     get_filters,
@@ -25,6 +26,7 @@ __all__ = [
     "Technical",
     "Ticker",
     "Valuation",
+    "from_url",
     "get_custom_screener_columns",
     "get_filter_options",
     "get_filters",

--- a/finvizfinance/screener/util.py
+++ b/finvizfinance/screener/util.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlparse
+
 from finvizfinance.constants import (
     CUSTOM_SCREENER_COLUMNS,
     filter_dict,
@@ -7,6 +10,9 @@ from finvizfinance.constants import (
     signal_dict,
 )
 from finvizfinance.util import validate_choice
+
+if TYPE_CHECKING:
+    from finvizfinance.screener.base import Base
 
 
 def get_signal() -> list[str]:
@@ -56,3 +62,150 @@ def get_custom_screener_columns() -> dict[int, str]:
         columns(dict): return the index and column name.
     """
     return CUSTOM_SCREENER_COLUMNS
+
+
+# --- URL -> screener config (issue #80) ------------------------------------
+#
+# finviz's own UI hands you a screener URL like
+# ``screener.ashx?v=111&f=idx_sp500,sh_avgvol_o500``. The reverse indexes below
+# turn that URL back into the filter state finvizfinance models, so a caller can
+# paste the URL instead of hand-translating every criterion into a filters dict.
+
+# ``prefix_urlcode`` token -> (filter name, option). Built from the same table
+# ``Base._set_filters`` walks forward, so it is an exact inverse. Every
+# (prefix, code) token is unique, so the mapping is unambiguous.
+_FILTER_TOKEN_INDEX: dict[str, tuple[str, str]] = {
+    f"{meta['prefix']}_{code}": (name, option)
+    for name, meta in filter_dict.items()
+    for option, code in meta["option"].items()
+    if code != ""
+}
+
+# finviz signal code (URL ``s=``) -> signal name.
+_SIGNAL_CODE_INDEX: dict[str, str] = {code: name for name, code in signal_dict.items()}
+
+
+def _view_classes() -> dict[int, type[Base]]:
+    """Map each finviz ``v_page`` view code to its screener subclass.
+
+    Imported lazily to avoid a package import cycle: the subclasses import
+    ``screener.base`` and ``screener.__init__`` imports this module.
+    """
+    from finvizfinance.screener.custom import Custom
+    from finvizfinance.screener.financial import Financial
+    from finvizfinance.screener.overview import Overview
+    from finvizfinance.screener.ownership import Ownership
+    from finvizfinance.screener.performance import Performance
+    from finvizfinance.screener.technical import Technical
+    from finvizfinance.screener.ticker import Ticker
+    from finvizfinance.screener.valuation import Valuation
+
+    classes: list[type[Base]] = [
+        Overview,
+        Valuation,
+        Ownership,
+        Performance,
+        Custom,
+        Financial,
+        Technical,
+        Ticker,
+    ]
+    mapping: dict[int, type[Base]] = {}
+    for cls in classes:
+        v = cls.v_page
+        if v is None:  # pragma: no cover - every screener subclass sets v_page
+            continue
+        mapping[v] = cls
+    return mapping
+
+
+def from_url(url: str) -> Base:
+    """Build a screener from a finviz screener URL (issue #80).
+
+    Reconstructs the *filter state* — view, filters, signal and ticker — from a
+    finviz ``screener.ashx`` URL (the link finviz puts in your address bar as you
+    click filters in its UI) and returns the matching screener subclass with that
+    state already applied. Call :meth:`screener_view` on the result as usual::
+
+        from finvizfinance import screener
+
+        overview = screener.from_url(
+            "https://finviz.com/screener.ashx?v=111&f=idx_sp500,sh_avgvol_o500"
+        )
+        df = overview.screener_view()
+
+    Only the selection parameters are interpreted: ``v`` (view -> subclass),
+    ``f`` (filters), ``s`` (signal) and ``t`` (ticker). Sort order (``o``),
+    pagination (``r``) and custom columns (``c``) are runtime concerns passed to
+    ``screener_view`` and are ignored here.
+
+    Fail-loud: an unknown view code, or any filter/signal code that does not map
+    to a known option, raises :class:`ValueError` naming the offending code rather
+    than silently dropping it and returning the wrong stocks.
+
+    Args:
+        url(str): a finviz screener URL, e.g.
+            ``"https://finviz.com/screener.ashx?v=121&f=idx_sp500,sec_technology"``.
+            A bare query string (``"v=121&f=idx_sp500"``) is also accepted.
+
+    Returns:
+        Base: the screener subclass for the URL's view, with filters/signal/ticker
+        applied.
+    """
+    if not isinstance(url, str):
+        raise TypeError(f"url must be a string, got {type(url).__name__}")
+
+    parsed = urlparse(url)
+    query = parsed.query
+    if not query and "=" in url:
+        # Accept a bare query string that has no scheme/host ("v=111&f=...").
+        query = url.split("?", 1)[-1]
+    params = parse_qs(query)
+    if not params:
+        raise ValueError(f"No screener parameters (v/f/s/t) found in URL: {url!r}")
+
+    view_classes = _view_classes()
+    if "v" in params:
+        raw_view = params["v"][0]
+        try:
+            v_page = int(raw_view)
+        except ValueError:
+            raise ValueError(
+                f"Invalid view code {raw_view!r}. "
+                f"Possible view codes: {list(view_classes)}"
+            ) from None
+        validate_choice(v_page, view_classes, "view code")
+        screener_cls = view_classes[v_page]
+    else:
+        # finviz defaults to the Overview view (v=111) when ``v`` is omitted.
+        screener_cls = view_classes[111]
+
+    filters_dict: dict[str, str] = {}
+    if "f" in params:
+        tokens = [token for value in params["f"] for token in value.split(",") if token]
+        unknown = [token for token in tokens if token not in _FILTER_TOKEN_INDEX]
+        if unknown:
+            raise ValueError(
+                f"Unrecognized screener filter code(s) {unknown} in URL. finviz "
+                "may have added filters not yet supported by finvizfinance, or "
+                "the URL is malformed."
+            )
+        for token in tokens:
+            name, option = _FILTER_TOKEN_INDEX[token]
+            filters_dict[name] = option
+
+    signal = ""
+    if "s" in params:
+        code = params["s"][0]
+        if code not in _SIGNAL_CODE_INDEX:
+            raise ValueError(
+                f"Unrecognized screener signal code {code!r} in URL. "
+                f"Possible signal codes: {list(_SIGNAL_CODE_INDEX)}"
+            )
+        signal = _SIGNAL_CODE_INDEX[code]
+
+    ticker = ",".join(params["t"]) if "t" in params else ""
+
+    screener = screener_cls()
+    screener.set_filter(signal=signal, filters_dict=filters_dict, ticker=ticker)
+    return screener

--- a/test/test_screener.py
+++ b/test/test_screener.py
@@ -4,7 +4,12 @@ import pytest
 from conftest import blocked_response, html_response, use_session
 
 from finvizfinance.exceptions import FinvizBlockedError, FinvizParseError
-from finvizfinance.screener import get_filter_options, get_filters, get_signal
+from finvizfinance.screener import (
+    from_url,
+    get_filter_options,
+    get_filters,
+    get_signal,
+)
 from finvizfinance.screener.custom import Custom
 from finvizfinance.screener.financial import Financial
 from finvizfinance.screener.overview import Overview
@@ -149,3 +154,103 @@ def test_screener_util_get_orders_and_columns():
     assert isinstance(get_orders(), list) and len(get_orders()) > 0
     columns = get_custom_screener_columns()
     assert isinstance(columns, dict) and len(columns) > 0
+
+
+# --- from_url: paste a finviz screener URL instead of building a filters dict ---
+
+
+def test_from_url_returns_overview_with_filters():
+    # The issue #80 example: a finviz screener URL round-trips into the same
+    # request params the equivalent set_filter() call would produce.
+    url = "https://finviz.com/screener.ashx?v=111&f=idx_sp500,sh_avgvol_o500"
+    screener = from_url(url)
+    assert isinstance(screener, Overview)
+    assert screener.request_params["v"] == 111
+    # Filters round-trip exactly (same codes, same order) back to the URL string.
+    assert screener.request_params["f"] == "idx_sp500,sh_avgvol_o500"
+
+
+@pytest.mark.parametrize(
+    "v_code, view_cls",
+    [
+        (111, Overview),
+        (121, Valuation),
+        (131, Ownership),
+        (141, Performance),
+        (151, Custom),
+        (161, Financial),
+        (171, Technical),
+        (411, Ticker),
+    ],
+)
+def test_from_url_selects_view_by_v_code(v_code, view_cls):
+    screener = from_url(f"https://finviz.com/screener.ashx?v={v_code}&f=idx_sp500")
+    assert isinstance(screener, view_cls)
+    assert screener.request_params["v"] == v_code
+
+
+def test_from_url_defaults_to_overview_when_v_absent():
+    # finviz serves the Overview view when ``v`` is omitted.
+    screener = from_url("https://finviz.com/screener.ashx?f=idx_sp500")
+    assert isinstance(screener, Overview)
+    assert screener.request_params["v"] == 111
+
+
+def test_from_url_accepts_bare_query_string():
+    screener = from_url("v=121&f=idx_sp500")
+    assert isinstance(screener, Valuation)
+    assert screener.request_params["f"] == "idx_sp500"
+
+
+def test_from_url_parses_signal():
+    screener = from_url("https://finviz.com/screener.ashx?v=111&s=ta_topgainers")
+    assert screener.request_params["s"] == "ta_topgainers"
+
+
+def test_from_url_parses_ticker():
+    screener = from_url("https://finviz.com/screener.ashx?v=411&t=AAPL,MSFT")
+    assert isinstance(screener, Ticker)
+    assert screener.request_params["t"] == "AAPL,MSFT"
+
+
+def test_from_url_ignores_order_and_pagination_params():
+    # ``o`` (sort) and ``r`` (page offset) are screener_view() concerns, not
+    # filter state; from_url ignores them without raising.
+    screener = from_url(
+        "https://finviz.com/screener.ashx?v=111&f=idx_sp500&o=-marketcap&r=21"
+    )
+    assert screener.request_params["f"] == "idx_sp500"
+    assert "o" not in screener.request_params
+    assert "r" not in screener.request_params
+
+
+def test_from_url_unknown_filter_code_raises():
+    # Fail-loud: an unmappable filter code is named and raised, never silently
+    # dropped (which would return the wrong stocks).
+    with pytest.raises(ValueError, match="totally_bogus"):
+        from_url("https://finviz.com/screener.ashx?v=111&f=idx_sp500,totally_bogus")
+
+
+def test_from_url_unknown_signal_code_raises():
+    with pytest.raises(ValueError, match="signal code"):
+        from_url("https://finviz.com/screener.ashx?v=111&s=not_a_signal")
+
+
+def test_from_url_unknown_view_code_raises():
+    with pytest.raises(ValueError, match="view code"):
+        from_url("https://finviz.com/screener.ashx?v=999&f=idx_sp500")
+
+
+def test_from_url_non_integer_view_raises():
+    with pytest.raises(ValueError, match="Invalid view code"):
+        from_url("https://finviz.com/screener.ashx?v=abc")
+
+
+def test_from_url_no_params_raises():
+    with pytest.raises(ValueError, match="No screener parameters"):
+        from_url("https://finviz.com/screener.ashx")
+
+
+def test_from_url_non_string_raises():
+    with pytest.raises(TypeError):
+        from_url(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## What

Adds `screener.from_url(url)` — build a screener straight from a finviz `screener.ashx` URL instead of hand-translating each criterion into a `filters_dict`.

```python
from finvizfinance import screener

foverview = screener.from_url(
    "https://finviz.com/screener.ashx?v=111&f=idx_sp500,sh_avgvol_o500"
)
df = foverview.screener_view()
```

Closes #80.

## How

- `from_url` reads the view code (`v`) and returns the matching screener subclass (`Overview`, `Valuation`, `Ownership`, `Performance`, `Custom`, `Financial`, `Technical`, `Ticker`), then applies the URL's filters (`f`), signal (`s`) and ticker (`t`) through the existing `set_filter`.
- The filter reverse-map is the **exact inverse** of `Base._set_filters`, built once from `filter_dict` — keyed by the full `prefix_urlcode` token because prefixes themselves contain underscores (`fa_pe`, `sh_avgvol`). Verified collision-free (1,627 unique tokens), so the mapping is unambiguous.
- A bare query string (`"v=121&f=idx_sp500"`) is accepted; a missing `v` defaults to Overview (finviz's own default).

## Fail-loud (design choice)

An unknown view code, or any filter/signal code that doesn't map to a known option, raises `ValueError` naming the offending code — it is **never** silently dropped. Silently dropping a filter would return the wrong stocks, the exact class of silent corruption the 1.4/1.5 reliability work targeted. This also surfaces new finviz filter codes as a loud, actionable error.

Sort order (`o`), pagination (`r`) and custom columns (`c`) are `screener_view()` concerns, not filter state, so they are ignored (documented).

## Scope

- No public API removed or changed; this is purely additive (`screener.from_url` + `__all__` entry).
- Pure string parsing — no new endpoint, no new dependency, no added drift/Wall surface.

## Tests

- 20 new offline tests in `test/test_screener.py`: exact filter round-trip, view selection across all 8 subclasses, bare-query + default-view, signal/ticker parsing, `o`/`r` ignored, and fail-loud on unknown filter/signal/view codes, non-integer `v`, empty URL, and non-string input.
- `pytest test`: 148 passed, 13 skipped (live). `screener/util.py` at 100% coverage; project total 87% (gate 86).
- `ruff check .`, `ruff format --check .`, and `mypy` all clean.
